### PR TITLE
implement `net_queryAll` method

### DIFF
--- a/common/rpctypes/types.go
+++ b/common/rpctypes/types.go
@@ -46,6 +46,17 @@ type QueryPeerResponse struct {
 	Offers []*types.Offer `json:"offers"`
 }
 
+// PeerWithOffers ...
+type PeerWithOffers struct {
+	Peer   []string       `json:"peer"`
+	Offers []*types.Offer `json:"offers"`
+}
+
+// QueryAllResponse ...
+type QueryAllResponse struct {
+	PeersWithOffers []*PeerWithOffers
+}
+
 // TakeOfferRequest ...
 type TakeOfferRequest struct {
 	Multiaddr      string  `json:"multiaddr"`

--- a/common/rpctypes/types.go
+++ b/common/rpctypes/types.go
@@ -54,7 +54,7 @@ type PeerWithOffers struct {
 
 // QueryAllResponse ...
 type QueryAllResponse struct {
-	PeersWithOffers []*PeerWithOffers
+	PeersWithOffers []*PeerWithOffers `json:"peersWithOffers"`
 }
 
 // TakeOfferRequest ...

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -39,6 +39,24 @@ curl -X POST http://127.0.0.1:5001 -d '{"jsonrpc":"2.0","id":"0","method":"net_d
 # {"jsonrpc":"2.0","result":{"peers":[["/ip4/127.0.0.1/tcp/9934/p2p/12D3KooWHLUrLnJtUbaGzTSi6azZavKhNgUZTtSiUZ9Uy12v1eZ7","/ip4/192.168.0.101/tcp/9934/p2p/12D3KooWHLUrLnJtUbaGzTSi6azZavKhNgUZTtSiUZ9Uy12v1eZ7"]]},"id":"0"}
 ```
 
+### `net_queryAll`
+
+Discover peers on the network via DHT that have active swap offers and gets all their swap offers.
+
+Parameters:
+- `provides` (optional): one of `ETH` or `XMR`, depending on which offer you are searching for. **Note**: Currently only `XMR` offers are supported. Default is `XMR`.
+- `searchTime` (optional): duration in seconds for which to perform the search. Default is 12s.
+
+Returns:
+- `peersWithOffers`: list of peers's multiaddresses and their current offers.
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:5001 -d '{"jsonrpc":"2.0","id":"0","method":"net_queryAll","params":{"searchTime":3}}' -H 'Content-Type: application/json'
+# {"jsonrpc":"2.0","result":{"PeersWithOffers":[{"peer":["/ip4/206.189.47.220/tcp/9900/p2p/12D3KooWGVzz2d2LSceVFFdqTYqmQXTqc5eWziw7PLRahCWGJhKB"],"offers":[{"ID":"a41b00034daee28df414ba337b3ddf942893a117f9a9fcf62bd5a664738710db","Provides":"XMR","MinimumAmount":0.1,"MaximumAmount":1,"ExchangeRate":0.5}]},{"peer":["/ip4/161.35.110.210/tcp/9900/p2p/12D3KooWS8iKxqsGTiL3Yc1VaAfg99U5km1AE7bWYQiuavXj3Yz6"],"offers":[{"ID":"25188edd7573f43fca5760f0aacdc1a358171a8fc6bdf11876fa937f77fc583c","Provides":"XMR","MinimumAmount":0.1,"MaximumAmount":1,"ExchangeRate":0.5}]}]},"id":"0"}
+```
+
 ### `net_queryPeer`
 
 Query a specific peer for their current active offers.

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -54,6 +54,52 @@ func (s *NetService) Addresses(_ *http.Request, _ *interface{}, resp *AddressesR
 	return nil
 }
 
+// QueryAll discovers peers who provide a certain coin and queries all of them for their current offers.
+func (s *NetService) QueryAll(_ *http.Request, req *rpctypes.DiscoverRequest, resp *rpctypes.QueryAllResponse) error {
+	peers, err := s.discover(req)
+	if err != nil {
+		return err
+	}
+
+	resp.PeersWithOffers = make([]*rpctypes.PeerWithOffers, len(peers))
+	for i, p := range peers {
+		multiaddrs := addrInfoToStrings(p)
+		resp.PeersWithOffers[i] = &rpctypes.PeerWithOffers{
+			Peer: multiaddrs,
+		}
+
+		for _, maddr := range multiaddrs {
+			who, err := net.StringToAddrInfo(maddr)
+			if err != nil {
+				return err
+			}
+
+			msg, err := s.net.Query(who)
+			if err != nil {
+				continue
+			}
+
+			resp.PeersWithOffers[i].Offers = msg.Offers
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *NetService) discover(req *rpctypes.DiscoverRequest) ([]peer.AddrInfo, error) {
+	searchTime, err := time.ParseDuration(fmt.Sprintf("%ds", req.SearchTime))
+	if err != nil {
+		return nil, err
+	}
+
+	if searchTime == 0 {
+		searchTime = defaultSearchTime
+	}
+
+	return s.net.Discover(req.Provides, searchTime)
+}
+
 // Discover discovers peers over the network that provide a certain coin up for `SearchTime` duration of time.
 func (s *NetService) Discover(_ *http.Request, req *rpctypes.DiscoverRequest, resp *rpctypes.DiscoverResponse) error {
 	searchTime, err := time.ParseDuration(fmt.Sprintf("%ds", req.SearchTime))

--- a/rpcclient/discover.go
+++ b/rpcclient/discover.go
@@ -39,3 +39,36 @@ func (c *Client) Discover(provides types.ProvidesCoin, searchTime uint64) ([][]s
 
 	return res.Peers, nil
 }
+
+// QueryAll calls net_queryAll.
+func (c *Client) QueryAll(provides types.ProvidesCoin, searchTime uint64) ([]*rpctypes.PeerWithOffers, error) {
+	const (
+		method = "net_queryAll"
+	)
+
+	req := &rpctypes.DiscoverRequest{
+		Provides:   provides,
+		SearchTime: searchTime,
+	}
+
+	params, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := rpctypes.PostRPC(c.endpoint, method, string(params))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	var res *rpctypes.QueryAllResponse
+	if err = json.Unmarshal(resp.Result, &res); err != nil {
+		return nil, err
+	}
+
+	return res.PeersWithOffers, nil
+}


### PR DESCRIPTION
implement `net_queryAll` method to discover peers making offers on the network and also get those offers in one command (instead of needing to do `discover` and `query` separately)
closes #119