### PR TITLE
fix: add wrapped TxOpts type

### DIFF
--- a/protocol/backend/backend.go
+++ b/protocol/backend/backend.go
@@ -160,7 +160,7 @@ func NewBackend(cfg *Config) (Backend, error) {
 	if cfg.EthereumPrivateKey != nil {
 		addr = common.EthereumPrivateKeyToAddress(cfg.EthereumPrivateKey)
 
-		// TODO: set gas limit and price?
+		// TODO: set gas limit + price based on network (#153)
 		txOpts, err = txsender.NewTxOpts(cfg.EthereumPrivateKey, cfg.ChainID)
 		if err != nil {
 			return nil, err

--- a/protocol/txsender/tx_opts.go
+++ b/protocol/txsender/tx_opts.go
@@ -1,0 +1,42 @@
+package txsender
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+// TxOpts wraps go-ethereum's *bind.TransactOpts.
+type TxOpts struct {
+	inner *bind.TransactOpts
+	mu    sync.Mutex // locks from TX start until receipt so we don't reuse ETH nonce values
+}
+
+// NewTxOpts returns a new *TxOpts from the given private key and chain ID
+func NewTxOpts(privkey *ecdsa.PrivateKey, chainID *big.Int) (*TxOpts, error) {
+	txOpts, err := bind.NewKeyedTransactorWithChainID(privkey, chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TxOpts{
+		inner: txOpts,
+	}, nil
+}
+
+// Inner returns the bind.TransactOpts contained
+func (txOpts *TxOpts) Inner() bind.TransactOpts {
+	return *txOpts.inner
+}
+
+// Lock ...
+func (txOpts *TxOpts) Lock() {
+	txOpts.mu.Lock()
+}
+
+// Unlock ...
+func (txOpts *TxOpts) Unlock() {
+	txOpts.mu.Unlock()
+}

--- a/protocol/txsender/tx_opts.go
+++ b/protocol/txsender/tx_opts.go
@@ -27,7 +27,7 @@ func NewTxOpts(privkey *ecdsa.PrivateKey, chainID *big.Int) (*TxOpts, error) {
 }
 
 // Inner returns a copy of bind.TransactOpts. The original is never used in a transaction,
-// so the copies given out do not have the Nonce, and Gas* fields initialized allowing them
+// so the copies given out do not have the Nonce, and Gas* fields initialised allowing them
 // to be initialized dynamically. Reference:
 // https://github.com/ethereum/go-ethereum/blob/v1.10.23/accounts/abi/bind/base.go#L49-L63
 func (txOpts *TxOpts) Inner() bind.TransactOpts {

--- a/protocol/txsender/tx_opts.go
+++ b/protocol/txsender/tx_opts.go
@@ -26,7 +26,10 @@ func NewTxOpts(privkey *ecdsa.PrivateKey, chainID *big.Int) (*TxOpts, error) {
 	}, nil
 }
 
-// Inner returns the bind.TransactOpts contained
+// Inner returns a copy of bind.TransactOpts. The original is never used in a transaction,
+// so the copies given out do not have the Nonce, and Gas* fields initialized allowing them
+// to be initialized dynamically. Reference:
+// https://github.com/ethereum/go-ethereum/blob/v1.10.23/accounts/abi/bind/base.go#L49-L63
 func (txOpts *TxOpts) Inner() bind.TransactOpts {
 	return *txOpts.inner
 }

--- a/protocol/txsender/tx_opts.go
+++ b/protocol/txsender/tx_opts.go
@@ -28,7 +28,7 @@ func NewTxOpts(privkey *ecdsa.PrivateKey, chainID *big.Int) (*TxOpts, error) {
 
 // Inner returns a copy of bind.TransactOpts. The original is never used in a transaction,
 // so the copies given out do not have the Nonce, and Gas* fields initialised allowing them
-// to be initialized dynamically. Reference:
+// to be initialised dynamically. Reference:
 // https://github.com/ethereum/go-ethereum/blob/v1.10.23/accounts/abi/bind/base.go#L49-L63
 func (txOpts *TxOpts) Inner() bind.TransactOpts {
 	return *txOpts.inner


### PR DESCRIPTION
add wrapped `TxOpts` type to fix multiple txsender concurrency issues, since the last PR (#158) made it so that the txsender was per-swap instead of global.