### PR TITLE
better json handling of Offer and Info types

### DIFF
--- a/common/types/ethasset.go
+++ b/common/types/ethasset.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"fmt"
+	"strings"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
@@ -14,6 +17,26 @@ func (asset EthAsset) String() string {
 	}
 	// TODO: get name of asset from contract?
 	return ethcommon.Address(asset).Hex()
+}
+
+// MarshalText returns the hex representation of the EthAsset
+func (asset EthAsset) MarshalText() ([]byte, error) {
+	return []byte(asset.String()), nil
+}
+
+// UnmarshalText assigns the EthAsset from the input text
+func (asset *EthAsset) UnmarshalText(input []byte) error {
+	inputStr := string(input)
+	switch {
+	case strings.EqualFold(inputStr, "ETH"):
+		*asset = EthAsset{}
+		return nil
+	case ethcommon.IsHexAddress(inputStr):
+		*asset = EthAsset(ethcommon.HexToAddress(inputStr))
+		return nil
+	default:
+		return fmt.Errorf("invalid asset value %q", inputStr)
+	}
 }
 
 // Address ...

--- a/common/types/ethasset_test.go
+++ b/common/types/ethasset_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthAsset_MarshalText(t *testing.T) {
+	jsonData, err := json.Marshal(EthAssetETH)
+	require.NoError(t, err)
+	require.Equal(t, `"ETH"`, string(jsonData))
+
+	addr := "0xADd47138bb89c3013B39F2e3B062B408c90E5179"
+	asset := EthAsset(ethcommon.HexToAddress(addr))
+	jsonData, err = json.Marshal(asset)
+	require.NoError(t, err)
+	quotedAddr := fmt.Sprintf("%q", addr)
+	require.Equal(t, quotedAddr, string(jsonData))
+}
+
+func TestEthAsset_UnmarshalText(t *testing.T) {
+	asset := EthAsset(ethcommon.Address{0x1}) // any non-zero initial value to make sure we overwrite it
+	err := json.Unmarshal([]byte(`"ETH"`), &asset)
+	require.NoError(t, err)
+	require.Equal(t, EthAssetETH, asset)
+
+	addr := "0xADd47138bb89c3013B39F2e3B062B408c90E5179"
+	quotedAddr := fmt.Sprintf("%q", addr)
+	err = json.Unmarshal([]byte(quotedAddr), &asset)
+	require.NoError(t, err)
+	expected := EthAsset(ethcommon.HexToAddress(addr))
+	require.Equal(t, expected, asset)
+
+	// Same exact test as above, but without the 0x prefix
+	quotedAddr = fmt.Sprintf("%q", addr[2:])
+	err = json.Unmarshal([]byte(quotedAddr), &asset)
+	require.NoError(t, err)
+	expected = EthAsset(ethcommon.HexToAddress(addr))
+	require.Equal(t, expected, asset)
+}
+
+func TestEthAsset_UnmarshalText_fail(t *testing.T) {
+	tooShortQuotedAddr := `"0xA9"`
+	asset := EthAsset(ethcommon.Address{0x1})
+	err := json.Unmarshal([]byte(tooShortQuotedAddr), &asset)
+	require.ErrorContains(t, err, "invalid asset value")
+}

--- a/common/types/hash.go
+++ b/common/types/hash.go
@@ -1,0 +1,35 @@
+package types
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// Hash represents a 32-byte hash
+type Hash = ethcommon.Hash
+
+// EmptyHash is an empty Hash
+var EmptyHash = Hash{}
+
+// IsHashZero returns true if the hash is all zeros, otherwise false
+func IsHashZero(h Hash) bool {
+	return h == EmptyHash
+}
+
+// HexToHash decodes a hex-encoded string into a hash
+func HexToHash(s string) (Hash, error) {
+	h, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+	if err != nil {
+		return Hash{}, err
+	}
+	if len(h) != len(Hash{}) {
+		return Hash{}, fmt.Errorf("invalid len=%d hash", len(h))
+	}
+
+	var hash Hash
+	copy(hash[:], h)
+	return hash, nil
+}

--- a/common/types/offer.go
+++ b/common/types/offer.go
@@ -2,60 +2,35 @@ package types
 
 import (
 	"crypto/rand"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/crypto/sha3"
 )
 
-// Hash represents a 32-byte hash
-type Hash [32]byte
-
-// EmptyHash is an empty Hash
-var EmptyHash = Hash{}
-
-// String returns the hex-encoded hash
-func (h Hash) String() string {
-	return hex.EncodeToString(h[:])
-}
-
-// IsZero returns true if the hash is all zeros, otherwise false
-func (h Hash) IsZero() bool {
-	return h == [32]byte{}
-}
-
-// HexToHash decodes a hex-encoded string into a hash
-func HexToHash(s string) (Hash, error) {
-	h, err := hex.DecodeString(s)
-	if err != nil {
-		return [32]byte{}, err
-	}
-
-	var hash [32]byte
-	copy(hash[:], h)
-	return hash, nil
-}
+// CurOfferVersion is the latest supported version of a serialised Offer struct
+var CurOfferVersion, _ = semver.NewVersion("v0.1.0")
 
 // Offer represents a swap offer
 type Offer struct {
-	id            Hash
-	Provides      ProvidesCoin
-	MinimumAmount float64
-	MaximumAmount float64
-	ExchangeRate  ExchangeRate
-	EthAsset      EthAsset
+	Version       *semver.Version `json:"version"`
+	ID            Hash            `json:"offer_id"`
+	Provides      ProvidesCoin    `json:"provides"`
+	MinimumAmount float64         `json:"min_amount"`
+	MaximumAmount float64         `json:"max_amount"`
+	ExchangeRate  ExchangeRate    `json:"exchange_rate"`
+	EthAsset      EthAsset        `json:"eth_asset"`
 }
 
-// NewOffer creates and returns an Offer with an initialised id field
+// NewOffer creates and returns an Offer with an initialised ID and Version fields
 func NewOffer(coin ProvidesCoin, minAmount float64, maxAmount float64, exRate ExchangeRate, ethAsset EthAsset) *Offer {
 	var buf [16]byte
 	if _, err := rand.Read(buf[:]); err != nil {
 		panic(err)
 	}
 	return &Offer{
-		id:            sha3.Sum256(buf[:]),
+		Version:       CurOfferVersion,
+		ID:            sha3.Sum256(buf[:]),
 		Provides:      coin,
 		MinimumAmount: minAmount,
 		MaximumAmount: maxAmount,
@@ -66,75 +41,22 @@ func NewOffer(coin ProvidesCoin, minAmount float64, maxAmount float64, exRate Ex
 
 // GetID returns the ID of the offer
 func (o *Offer) GetID() Hash {
-	if o.id.IsZero() {
+	if IsHashZero(o.ID) {
 		panic("offer was improperly initialised")
 	}
-	return o.id
+	return o.ID
 }
 
 // String ...
 func (o *Offer) String() string {
 	return fmt.Sprintf("Offer ID=%s Provides=%v MinimumAmount=%v MaximumAmount=%v ExchangeRate=%v EthAsset=%v",
-		o.id,
+		o.ID,
 		o.Provides,
 		o.MinimumAmount,
 		o.MaximumAmount,
 		o.ExchangeRate,
 		o.EthAsset,
 	)
-}
-
-// MarshalJSON is a custom JSON marshaller for Offer which enables serialisation of the private id field
-func (o Offer) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		ID            string
-		Provides      ProvidesCoin
-		MinimumAmount float64
-		MaximumAmount float64
-		ExchangeRate  ExchangeRate
-		EthAsset      string
-	}{
-		ID:            o.id.String(),
-		Provides:      o.Provides,
-		MinimumAmount: o.MinimumAmount,
-		MaximumAmount: o.MaximumAmount,
-		ExchangeRate:  o.ExchangeRate,
-		EthAsset:      ethcommon.Address(o.EthAsset).Hex(),
-	})
-}
-
-// UnmarshalJSON is a custom JSON marshaller for Offer which enables deserialization of the private id field
-func (o *Offer) UnmarshalJSON(data []byte) error {
-	ou := &struct {
-		ID            string
-		Provides      ProvidesCoin
-		MinimumAmount float64
-		MaximumAmount float64
-		ExchangeRate  ExchangeRate
-		EthAsset      string
-	}{}
-	if err := json.Unmarshal(data, &ou); err != nil {
-		return err
-	}
-	id, err := hex.DecodeString(ou.ID)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal Offer ID err=%w", err)
-	}
-	if len(id) != len(o.id) {
-		return fmt.Errorf("offer ID has invalid length=%d", len(id))
-	}
-	copy(o.id[:], id)
-	o.Provides = ou.Provides
-	o.MinimumAmount = ou.MinimumAmount
-	o.MaximumAmount = ou.MaximumAmount
-	o.ExchangeRate = ou.ExchangeRate
-	if ou.EthAsset == "" {
-		// Default to EthAssetETH
-		o.EthAsset = EthAssetETH
-	} else {
-		o.EthAsset = EthAsset(ethcommon.HexToAddress(ou.EthAsset))
-	}
-	return nil
 }
 
 // OfferExtra represents extra data that is passed when an offer is made.

--- a/common/types/offer_test.go
+++ b/common/types/offer_test.go
@@ -13,25 +13,37 @@ import (
 func TestOffer_MarshalJSON(t *testing.T) {
 	offer := NewOffer(ProvidesXMR, 100.0, 200.0, 1.5, EthAssetETH)
 	id := offer.GetID()
-	require.False(t, id.IsZero())
+	require.False(t, IsHashZero(id))
 
-	expected := fmt.Sprintf(
-		`{"ID":"%s","Provides":"XMR","MinimumAmount":100,"MaximumAmount":200,"ExchangeRate":1.5,`+
-			`"EthAsset":"0x0000000000000000000000000000000000000000"}`, id)
+	expected := fmt.Sprintf(`{
+        "version": "0.1.0",
+		"offer_id": "%s",
+		"provides": "XMR",
+		"min_amount": 100,
+		"max_amount": 200,
+		"exchange_rate": 1.5,
+		"eth_asset": "ETH"
+	}`, id)
 	jsonData, err := json.Marshal(offer)
 	require.NoError(t, err)
-	require.Equal(t, expected, string(jsonData))
+	require.JSONEq(t, expected, string(jsonData))
 }
 
 func TestOffer_UnmarshalJSON(t *testing.T) {
-	idStr := "0102030405060708091011121314151617181920212223242526272829303131"
-	offerJSON := fmt.Sprintf(
-		`{"ID":"%s","Provides":"XMR","MinimumAmount":100,"MaximumAmount":200,"ExchangeRate":1.5,`+
-			`"EthAsset":"0x0000000000000000000000000000000000000001"}`, idStr)
+	idStr := "0x0102030405060708091011121314151617181920212223242526272829303131"
+	offerJSON := fmt.Sprintf(`{
+		"version": "0.1.0",
+		"offer_id": "%s",
+		"provides": "XMR",
+		"min_amount": 100,
+		"max_amount": 200,
+		"exchange_rate": 1.5,
+		"eth_asset":"0x0000000000000000000000000000000000000001"
+	}`, idStr)
 	var offer Offer
 	err := json.Unmarshal([]byte(offerJSON), &offer)
 	require.NoError(t, err)
-	assert.Equal(t, idStr, offer.id.String())
+	assert.Equal(t, idStr, offer.ID.String())
 	assert.Equal(t, offer.Provides, ProvidesXMR)
 	assert.Equal(t, offer.MinimumAmount, float64(100))
 	assert.Equal(t, offer.MaximumAmount, float64(200))
@@ -41,12 +53,19 @@ func TestOffer_UnmarshalJSON(t *testing.T) {
 
 func TestOffer_UnmarshalJSON_DefaultAsset(t *testing.T) {
 	idStr := "0102030405060708091011121314151617181920212223242526272829303131"
-	offerJSON := fmt.Sprintf(
-		`{"ID":"%s","Provides":"XMR","MinimumAmount":100,"MaximumAmount":200,"ExchangeRate":1.5}`, idStr)
+	offerJSON := fmt.Sprintf(`{
+		"version": "0.1.0",
+		"offer_id": "%s",
+		"provides": "XMR",
+		"min_amount": 100,
+		"max_amount": 200,
+		"exchange_rate": 1.5
+	}`, idStr)
 	var offer Offer
 	err := json.Unmarshal([]byte(offerJSON), &offer)
 	require.NoError(t, err)
-	assert.Equal(t, idStr, offer.id.String())
+	assert.Equal(t, CurOfferVersion, offer.Version.String())
+	assert.Equal(t, idStr, offer.ID.String())
 	assert.Equal(t, offer.Provides, ProvidesXMR)
 	assert.Equal(t, offer.MinimumAmount, float64(100))
 	assert.Equal(t, offer.MaximumAmount, float64(200))
@@ -61,14 +80,23 @@ func TestOffer_MarshalJSON_RoundTrip(t *testing.T) {
 	var offer2 Offer
 	err = json.Unmarshal(offerJSON, &offer2)
 	require.NoError(t, err)
+	assert.Equal(t, offer1.Version.String(), offer2.Version.String())
+	offer2.Version = offer1.Version // make the version pointers equal for the next line
 	assert.EqualValues(t, offer1, &offer2)
 }
 
 func TestOffer_UnmarshalJSON_BadID(t *testing.T) {
-	offerJSON := []byte(`{"ID":"","Provides":"XMR","MinimumAmount":100,"MaximumAmount":200,"ExchangeRate":1.5,` +
-		`"EthAsset":"0x0000000000000000000000000000000000000000"}`)
+	offerJSON := []byte(`{
+		"version": "0.1.0",
+		"offer_id": "",
+		"provides": "XMR",
+		"min_Amount": 100,
+		"max_Amount": 200,
+		"exchange_rate": 1.5,
+		"eth_asset": "ETH"
+	}`)
 	var offer Offer
 	err := json.Unmarshal(offerJSON, &offer)
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "offer ID has invalid length=0")
+	require.ErrorContains(t, err, "hex string has length 0, want 64")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ require (
 	filippo.io/edwards25519 v1.0.0
 	github.com/ChainSafe/chaindb v0.1.5-0.20221010190531-f900218c88f8
 	github.com/MarinX/monerorpc v1.0.5
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/athanorlabs/cgo-dleq v0.0.0-20220929204103-ca62cc9baa28
+	github.com/athanorlabs/go-relayer v0.0.0-20221103034307-cde70ecbb543
+	github.com/athanorlabs/go-relayer-client v0.0.0-20221103041240-2aad2e8fc742
 	github.com/btcsuite/btcd/btcutil v1.1.2
 	github.com/chyeh/pubip v0.0.0-20170203095919-b7e679cf541c
 	github.com/ethereum/go-ethereum v1.10.25
@@ -31,8 +34,6 @@ require (
 require (
 	github.com/ChainSafe/log15 v1.0.0 // indirect
 	github.com/DataDog/zstd v1.4.1 // indirect
-	github.com/athanorlabs/go-relayer v0.0.0-20221103034307-cde70ecbb543 // indirect
-	github.com/athanorlabs/go-relayer-client v0.0.0-20221103041240-2aad2e8fc742 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,10 +51,10 @@ github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/MarinX/monerorpc v1.0.4 h1:p1ui0bD8s7tdC1zbFy3UacwDCyBo5wCMa1aVfDPAgxI=
-github.com/MarinX/monerorpc v1.0.4/go.mod h1:NohAIf5kJ4pS0sO9mbEQkI1dLHuxd4L0DX2Zou0Yofo=
 github.com/MarinX/monerorpc v1.0.5 h1:3brpRWTLngzjlAGprmLWuAY16QCSiwokoaGdpu+/ukc=
 github.com/MarinX/monerorpc v1.0.5/go.mod h1:NohAIf5kJ4pS0sO9mbEQkI1dLHuxd4L0DX2Zou0Yofo=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
@@ -86,8 +86,6 @@ github.com/btcsuite/btcd v0.23.0 h1:V2/ZgjfDFIygAX3ZapeigkVBoVUtOJKSwrhZdlpSvaA=
 github.com/btcsuite/btcd v0.23.0/go.mod h1:0QJIIN1wwIXF/3G/m87gIwGniDMDQqjVn4SZgnFpsYY=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
-github.com/btcsuite/btcd/btcec/v2 v2.2.1 h1:xP60mv8fvp+0khmrN0zTdPC3cNm24rfeE6lh2R/Yv3E=
-github.com/btcsuite/btcd/btcec/v2 v2.2.1/go.mod h1:9/CSmJxmuvqzX9Wh2fXMWToLOHhPd11lSPuIupwTkI8=
 github.com/btcsuite/btcd/btcec/v2 v2.3.0 h1:S/6K1GEwlEsFzZP4cOOl5mg6PEd/pr0zz7hvXcaxhJ4=
 github.com/btcsuite/btcd/btcec/v2 v2.3.0/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
@@ -685,7 +683,7 @@ github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.3.4 h1:3Z3Eu6FGHZWSfNKJTOUiPatWwfc7DzJRU04jFUqJODw=
+github.com/rivo/uniseg v0.4.2 h1:YwD0ulJSJytLpiaWua0sBDusfsCZohxjxzVTYjwxfV8=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -841,8 +839,6 @@ golang.org/x/crypto v0.0.0-20200602180216-279210d13fed/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be h1:fmw3UbQh+nxngCAHrDCCztao/kbYFnWjoqop8dHx05A=
-golang.org/x/crypto v0.0.0-20220926161630-eccd6366d1be/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -928,8 +924,6 @@ golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234 h1:RDqmgfe7SvlMWoqC3xwQ2blLO3fcWcxMa3eBLRdRW7E=
-golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1028,8 +1022,6 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -1041,7 +1033,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/protocol/swap/types.go
+++ b/protocol/swap/types.go
@@ -1,8 +1,13 @@
 package swap
 
 import (
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/athanorlabs/atomic-swap/common/types"
 )
+
+// CurInfoVersion is the latest supported version of a serialised Info struct
+var CurInfoVersion, _ = semver.NewVersion("v0.1.0")
 
 type (
 	Status = types.Status //nolint:revive
@@ -10,13 +15,14 @@ type (
 
 // Info contains the details of the swap as well as its status.
 type Info struct {
-	ID             types.Hash // swap offer ID
-	Provides       types.ProvidesCoin
-	ProvidedAmount float64
-	ReceivedAmount float64
-	ExchangeRate   types.ExchangeRate
-	EthAsset       types.EthAsset
-	Status         Status
+	Version        *semver.Version     `json:"version"`
+	ID             types.Hash          `json:"offer_id"` // swap offer ID
+	Provides       types.ProvidesCoin  `json:"provides"`
+	ProvidedAmount float64             `json:"provided_amount"`
+	ReceivedAmount float64             `json:"received_amount"`
+	ExchangeRate   types.ExchangeRate  `json:"exchange_rate"`
+	EthAsset       types.EthAsset      `json:"eth_asset"`
+	Status         Status              `json:"status"`
 	statusCh       <-chan types.Status `json:"-"`
 }
 
@@ -32,6 +38,7 @@ func NewInfo(
 	statusCh <-chan types.Status,
 ) *Info {
 	info := &Info{
+		Version:        CurInfoVersion,
 		ID:             id,
 		Provides:       provides,
 		ProvidedAmount: providedAmount,

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -135,7 +135,7 @@ func (s *swapState) handleNotifyETHLocked(msg *message.NotifyETHLocked) (net.Mes
 		return nil, errMissingAddress
 	}
 
-	if msg.ContractSwapID.IsZero() {
+	if types.IsHashZero(msg.ContractSwapID) {
 		return nil, errNilContractSwapID
 	}
 

--- a/protocol/xmrmaker/net.go
+++ b/protocol/xmrmaker/net.go
@@ -85,7 +85,7 @@ func (b *Instance) HandleInitiateMessage(msg *net.SendKeysMessage) (net.SwapStat
 	if err != nil {
 		return nil, nil, err
 	}
-	if id.IsZero() {
+	if types.IsHashZero(id) {
 		return nil, nil, errOfferIDNotSet
 	}
 

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -158,7 +158,7 @@ func newTestXMRTakerSendKeysMessage(t *testing.T) (*net.SendKeysMessage, *pcommo
 func newSwap(t *testing.T, ss *swapState, claimKey, refundKey types.Hash, amount *big.Int,
 	timeout time.Duration) ethcommon.Hash {
 	tm := big.NewInt(int64(timeout.Seconds()))
-	if claimKey.IsZero() {
+	if types.IsHashZero(claimKey) {
 		claimKey = ss.secp256k1Pub.Keccak256()
 	}
 


### PR DESCRIPTION
This PR is not for `master`. It's for the `noot/db-swap` branch.

Since we are going to be storing the JSON from the `Offer` and `Info` structs in a non-structured database, this PR adds a version field and cleaner JSON handling (offer IDs and EthAsset addresses are in hex instead of comma separated bytes).