### PR TITLE
renamed backend functions ETH to ETHClient and XMR to XMRClient

### DIFF
--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -446,9 +446,9 @@ func (d *daemon) make(c *cli.Context) error { //nolint:gocyclo
 		return err
 	}
 
-	defer swapBackend.XMR().Close()
+	defer swapBackend.XMRClient().Close()
 	log.Infof("created backend with monero endpoint %s and ethereum endpoint %s",
-		swapBackend.XMR().Endpoint(), ethEndpoint)
+		swapBackend.XMRClient().Endpoint(), ethEndpoint)
 
 	a, b, err := getProtocolInstances(c, cfg, swapBackend, sdb, host)
 	if err != nil {
@@ -512,7 +512,7 @@ func maybeBackgroundMine(ctx context.Context, devXMRMaker bool, b backend.Backen
 		return nil
 	}
 
-	addr, err := b.XMR().GetAddress(0)
+	addr, err := b.XMRClient().GetAddress(0)
 	if err != nil {
 		return err
 	}

--- a/cmd/swaprecover/main.go
+++ b/cmd/swaprecover/main.go
@@ -206,7 +206,7 @@ func (inst *instance) recover(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	defer b.XMR().Close()
+	defer b.XMRClient().Close()
 
 	dataDir := filepath.Dir(filepath.Clean(infofilePath))
 

--- a/protocol/backend/backend.go
+++ b/protocol/backend/backend.go
@@ -25,8 +25,8 @@ var (
 // Backend provides an interface for both the XMRTaker and XMRMaker into the Monero/Ethereum chains.
 // It also interfaces with the network layer.
 type Backend interface {
-	XMR() monero.WalletClient
-	ETH() extethclient.EthClient
+	XMRClient() monero.WalletClient
+	ETHClient() extethclient.EthClient
 	net.MessageSender
 
 	// NewTxSender creates a new transaction sender, called per-swap
@@ -116,11 +116,11 @@ func NewBackend(cfg *Config) (Backend, error) {
 	}, nil
 }
 
-func (b *backend) XMR() monero.WalletClient {
+func (b *backend) XMRClient() monero.WalletClient {
 	return b.moneroWallet
 }
 
-func (b *backend) ETH() extethclient.EthClient {
+func (b *backend) ETHClient() extethclient.EthClient {
 	return b.ethClient
 }
 
@@ -128,7 +128,7 @@ func (b *backend) NewTxSender(asset ethcommon.Address, erc20Contract *contracts.
 	if !b.ethClient.HasPrivateKey() {
 		return txsender.NewExternalSender(b.ctx, b.env, b.ethClient.Raw(), b.contractAddr, asset)
 	}
-	return txsender.NewSenderWithPrivateKey(b.ctx, b.ETH(), b.contract, erc20Contract), nil
+	return txsender.NewSenderWithPrivateKey(b.ctx, b.ETHClient(), b.contract, erc20Contract), nil
 }
 
 func (b *backend) Contract() *contracts.SwapFactory {

--- a/protocol/backend/backend_test.go
+++ b/protocol/backend/backend_test.go
@@ -46,7 +46,7 @@ func TestWaitForReceipt(t *testing.T) {
 		ethClient: extendedEC,
 	}
 
-	receipt, err := b.ETH().WaitForReceipt(ctx, tx.Hash())
+	receipt, err := b.ETHClient().WaitForReceipt(ctx, tx.Hash())
 	require.NoError(t, err)
 	require.Equal(t, tx.Hash(), receipt.TxHash)
 }

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -48,7 +48,7 @@ func ConvertContractSwapToMsg(swap contracts.SwapFactorySwap) *message.ContractS
 // AssetSymbol returns the symbol for the given asset.
 func AssetSymbol(b backend.Backend, asset types.EthAsset) (string, error) {
 	if asset != types.EthAssetETH {
-		_, symbol, _, err := b.ETH().ERC20Info(b.Ctx(), asset.Address())
+		_, symbol, _, err := b.ETHClient().ERC20Info(b.Ctx(), asset.Address())
 		if err != nil {
 			return "", fmt.Errorf("failed to get ERC20 info: %w", err)
 		}

--- a/protocol/xmrmaker/backend_offers.go
+++ b/protocol/xmrmaker/backend_offers.go
@@ -13,11 +13,11 @@ func (b *Instance) MakeOffer(
 	relayerEndpoint string,
 	relayerCommission float64,
 ) (*types.OfferExtra, error) {
-	b.backend.XMR().Lock()
-	defer b.backend.XMR().Unlock()
+	b.backend.XMRClient().Lock()
+	defer b.backend.XMRClient().Unlock()
 
 	// get monero balance
-	balance, err := b.backend.XMR().GetBalance(0)
+	balance, err := b.backend.XMRClient().GetBalance(0)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrmaker/event_test.go
+++ b/protocol/xmrmaker/event_test.go
@@ -23,11 +23,11 @@ func TestSwapState_handleEvent_EventContractReady(t *testing.T) {
 	require.NoError(t, err)
 	newSwap(t, s, [32]byte{}, [32]byte{}, desiredAmount.BigInt(), duration)
 
-	txOpts, err := s.ETH().TxOpts(s.ctx)
+	txOpts, err := s.ETHClient().TxOpts(s.ctx)
 	require.NoError(t, err)
 	tx, err := s.Contract().SetReady(txOpts, s.contractSwap)
 	require.NoError(t, err)
-	tests.MineTransaction(t, s.ETH().Raw(), tx)
+	tests.MineTransaction(t, s.ETHClient().Raw(), tx)
 
 	// runContractEventWatcher will trigger EventContractReady,
 	// which will then set the next expected event to EventExit.

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -79,14 +79,14 @@ func (b *Instance) GetOngoingSwapState(id types.Hash) common.SwapState {
 // GetMoneroBalance returns the primary wallet address, and current balance of the user's monero
 // wallet.
 func (b *Instance) GetMoneroBalance() (string, *wallet.GetBalanceResponse, error) {
-	addr, err := b.backend.XMR().GetAddress(0)
+	addr, err := b.backend.XMRClient().GetAddress(0)
 	if err != nil {
 		return "", nil, err
 	}
-	if err = b.backend.XMR().Refresh(); err != nil {
+	if err = b.backend.XMRClient().Refresh(); err != nil {
 		return "", nil, err
 	}
-	balance, err := b.backend.XMR().GetBalance(0)
+	balance, err := b.backend.XMRClient().GetBalance(0)
 	if err != nil {
 		return "", nil, err
 	}

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -100,7 +100,7 @@ func (s *swapState) handleNotifyETHLocked(msg *message.NotifyETHLocked) (net.Mes
 	}
 
 	contractAddr := ethcommon.HexToAddress(msg.Address)
-	if _, err := contracts.CheckSwapFactoryContractCode(s.ctx, s.Backend.ETH().Raw(), contractAddr); err != nil {
+	if _, err := contracts.CheckSwapFactoryContractCode(s.ctx, s.Backend.ETHClient().Raw(), contractAddr); err != nil {
 		return nil, err
 	}
 
@@ -141,7 +141,7 @@ func (s *swapState) runT0ExpirationHandler() {
 	// with --miner.blockTime!!!
 	waitCh := make(chan error)
 	go func() {
-		waitCh <- s.ETH().WaitForTimestamp(waitCtx, s.t0)
+		waitCh <- s.ETHClient().WaitForTimestamp(waitCtx, s.t0)
 		close(waitCh)
 	}()
 

--- a/protocol/xmrmaker/net.go
+++ b/protocol/xmrmaker/net.go
@@ -27,7 +27,7 @@ func (b *Instance) initiate(
 		return nil, errProtocolAlreadyInProgress
 	}
 
-	balance, err := b.backend.XMR().GetBalance(0)
+	balance, err := b.backend.XMRClient().GetBalance(0)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrmaker/recovery_test.go
+++ b/protocol/xmrmaker/recovery_test.go
@@ -35,13 +35,13 @@ func newTestRecoveryState(t *testing.T, timeout time.Duration) (*recoveryState, 
 func TestClaimOrRecover_Claim(t *testing.T) {
 	// test case where XMRMaker is able to claim ether from the contract
 	rs, _ := newTestRecoveryState(t, 24*time.Hour)
-	txOpts, err := rs.ss.ETH().TxOpts(rs.ss.ctx)
+	txOpts, err := rs.ss.ETHClient().TxOpts(rs.ss.ctx)
 	require.NoError(t, err)
 
 	// set contract to Ready
 	tx, err := rs.ss.Contract().SetReady(txOpts, rs.ss.contractSwap)
 	require.NoError(t, err)
-	tests.MineTransaction(t, rs.ss.ETH().Raw(), tx)
+	tests.MineTransaction(t, rs.ss.ETHClient().Raw(), tx)
 
 	// assert we can claim ether
 	res, err := rs.ClaimOrRecover()
@@ -52,12 +52,12 @@ func TestClaimOrRecover_Claim(t *testing.T) {
 func TestClaimOrRecover_Recover(t *testing.T) {
 	// test case where XMRMaker is able to reclaim their monero, after XMRTaker refunds
 	rs, _ := newTestRecoveryState(t, 24*time.Hour)
-	txOpts, err := rs.ss.ETH().TxOpts(rs.ss.ctx)
+	txOpts, err := rs.ss.ETHClient().TxOpts(rs.ss.ctx)
 	require.NoError(t, err)
 
 	// TODO: when recovery from disk is implemented, re-add this
 	// db.EXPECT().PutOffer(rs.ss.offer)
-	monero.MineMinXMRBalance(t, rs.ss.XMR(), common.MoneroToPiconero(1))
+	monero.MineMinXMRBalance(t, rs.ss.XMRClient(), common.MoneroToPiconero(1))
 
 	// lock XMR
 	rs.ss.setXMRTakerPublicKeys(rs.ss.pubkeys, nil)
@@ -68,7 +68,7 @@ func TestClaimOrRecover_Recover(t *testing.T) {
 	sc := rs.ss.getSecret()
 	tx, err := rs.ss.Contract().Refund(txOpts, rs.ss.contractSwap, sc)
 	require.NoError(t, err)
-	tests.MineTransaction(t, rs.ss.ETH().Raw(), tx)
+	tests.MineTransaction(t, rs.ss.ETHClient().Raw(), tx)
 
 	// assert XMRMaker can reclaim their monero
 	res, err := rs.ClaimOrRecover()

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -116,7 +116,7 @@ func newSwapState(
 
 	var sender txsender.Sender
 	if offer.EthAsset != types.EthAssetETH {
-		erc20Contract, err := contracts.NewIERC20(offer.EthAsset.Address(), b.ETH().Raw())
+		erc20Contract, err := contracts.NewIERC20(offer.EthAsset.Address(), b.ETHClient().Raw())
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func newSwapState(
 		}
 	}
 
-	walletScanHeight, err := b.XMR().GetChainHeight()
+	walletScanHeight, err := b.XMRClient().GetChainHeight()
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func newSwapState(
 		walletScanHeight -= monero.MinSpendConfirmations
 	}
 
-	ethHeader, err := b.ETH().Raw().HeaderByNumber(b.Ctx(), nil)
+	ethHeader, err := b.ETHClient().Raw().HeaderByNumber(b.Ctx(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func newSwapState(
 
 	readyWatcher := watcher.NewEventFilter(
 		ctx,
-		b.ETH().Raw(),
+		b.ETHClient().Raw(),
 		b.ContractAddr(),
 		ethHeader.Number,
 		readyTopic,
@@ -166,7 +166,7 @@ func newSwapState(
 
 	refundedWatcher := watcher.NewEventFilter(
 		ctx,
-		b.ETH().Raw(),
+		b.ETHClient().Raw(),
 		b.ContractAddr(),
 		ethHeader.Number,
 		refundedTopic,
@@ -220,7 +220,7 @@ func (s *swapState) SendKeysMessage() (*net.SendKeysMessage, error) {
 		PrivateViewKey:     s.privkeys.ViewKey().Hex(),
 		DLEqProof:          hex.EncodeToString(s.dleqProof.Proof()),
 		Secp256k1PublicKey: s.secp256k1Pub.String(),
-		EthAddress:         s.ETH().Address().String(),
+		EthAddress:         s.ETHClient().Address().String(),
 	}, nil
 }
 
@@ -336,15 +336,15 @@ func (s *swapState) reclaimMonero(skA *mcrypto.PrivateSpendKey) (mcrypto.Address
 		return "", err
 	}
 
-	s.XMR().Lock()
-	defer s.XMR().Unlock()
-	return monero.CreateWallet("xmrmaker-swap-wallet", s.Env(), s.XMR(), kpAB, s.walletScanHeight)
+	s.XMRClient().Lock()
+	defer s.XMRClient().Unlock()
+	return monero.CreateWallet("xmrmaker-swap-wallet", s.Env(), s.XMRClient(), kpAB, s.walletScanHeight)
 }
 
 func (s *swapState) filterForRefund() (*mcrypto.PrivateSpendKey, error) {
 	const refundedEvent = "Refunded"
 
-	logs, err := s.ETH().Raw().FilterLogs(s.ctx, eth.FilterQuery{
+	logs, err := s.ETHClient().Raw().FilterLogs(s.ctx, eth.FilterQuery{
 		Addresses: []ethcommon.Address{s.ContractAddr()},
 		Topics:    [][]ethcommon.Hash{{refundedTopic}},
 	})
@@ -453,7 +453,7 @@ func (s *swapState) setTimeouts(t0, t1 *big.Int) {
 // if the balance doesn't match what we're expecting to receive, or the public keys in the contract
 // aren't what we expect, we error and abort the swap.
 func (s *swapState) checkContract(txHash ethcommon.Hash) error {
-	tx, _, err := s.ETH().Raw().TransactionByHash(s.ctx, txHash)
+	tx, _, err := s.ETHClient().Raw().TransactionByHash(s.ctx, txHash)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func (s *swapState) checkContract(txHash ethcommon.Hash) error {
 		return errInvalidETHLockedTransaction
 	}
 
-	receipt, err := s.ETH().WaitForReceipt(s.ctx, txHash)
+	receipt, err := s.ETHClient().WaitForReceipt(s.ctx, txHash)
 	if err != nil {
 		return fmt.Errorf("failed to get receipt for New transaction: %w", err)
 	}
@@ -525,10 +525,10 @@ func (s *swapState) lockFunds(amount common.MoneroAmount) (*message.NotifyXMRLoc
 	swapDestAddr := mcrypto.SumSpendAndViewKeys(s.xmrtakerPublicKeys, s.pubkeys).Address(s.Env())
 	log.Infof("going to lock XMR funds, amount(piconero)=%d", amount)
 
-	s.XMR().Lock()
-	defer s.XMR().Unlock()
+	s.XMRClient().Lock()
+	defer s.XMRClient().Unlock()
 
-	balance, err := s.XMR().GetBalance(0)
+	balance, err := s.XMRClient().GetBalance(0)
 	if err != nil {
 		return nil, err
 	}
@@ -536,7 +536,7 @@ func (s *swapState) lockFunds(amount common.MoneroAmount) (*message.NotifyXMRLoc
 	log.Debug("total XMR balance: ", balance.Balance)
 	log.Info("unlocked XMR balance: ", balance.UnlockedBalance)
 
-	transResp, err := s.XMR().Transfer(swapDestAddr, 0, uint64(amount))
+	transResp, err := s.XMRClient().Transfer(swapDestAddr, 0, uint64(amount))
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +548,7 @@ func (s *swapState) lockFunds(amount common.MoneroAmount) (*message.NotifyXMRLoc
 	//       separate monero-wallet-rpc instance for A+B wallets or carefully releasing the
 	//       lock between confirmations and re-opening the A+B wallet after grabbing the
 	//       lock again.
-	transfer, err := s.XMR().WaitForReceipt(&monero.WaitForReceiptRequest{
+	transfer, err := s.XMRClient().WaitForReceipt(&monero.WaitForReceiptRequest{
 		Ctx:              s.ctx,
 		TxID:             transResp.TxHash,
 		DestAddr:         swapDestAddr,

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -25,9 +25,9 @@ func TestSwapState_handleEvent_EventETHClaimed(t *testing.T) {
 
 	// backend simulates the xmrmaker's instance
 	backend := newBackend(t)
-	err := backend.XMR().CreateWallet("test-wallet", "")
+	err := backend.XMRClient().CreateWallet("test-wallet", "")
 	require.NoError(t, err)
-	monero.MineMinXMRBalance(t, backend.XMR(), common.MoneroToPiconero(1))
+	monero.MineMinXMRBalance(t, backend.XMRClient(), common.MoneroToPiconero(1))
 
 	// invalid SendKeysMessage should result in an error
 	msg := &net.SendKeysMessage{}
@@ -41,7 +41,7 @@ func TestSwapState_handleEvent_EventETHClaimed(t *testing.T) {
 	msg, err = s.SendKeysMessage()
 	require.NoError(t, err)
 	msg.PrivateViewKey = s.privkeys.ViewKey().Hex()
-	msg.EthAddress = s.ETH().Address().String()
+	msg.EthAddress = s.ETHClient().Address().String()
 
 	err = s.HandleProtocolMessage(msg)
 	require.NoError(t, err)
@@ -59,12 +59,12 @@ func TestSwapState_handleEvent_EventETHClaimed(t *testing.T) {
 	xmrAddr := kp.Address(common.Mainnet)
 
 	// lock xmr
-	tResp, err := backend.XMR().Transfer(xmrAddr, 0, uint64(amt))
+	tResp, err := backend.XMRClient().Transfer(xmrAddr, 0, uint64(amt))
 	require.NoError(t, err)
 	t.Logf("transferred %d pico XMR (fees %d) to account %s", tResp.Amount, tResp.Fee, xmrAddr)
 	require.Equal(t, uint64(amt), tResp.Amount)
 
-	transfer, err := backend.XMR().WaitForReceipt(&monero.WaitForReceiptRequest{
+	transfer, err := backend.XMRClient().WaitForReceipt(&monero.WaitForReceiptRequest{
 		Ctx:              s.ctx,
 		TxID:             tResp.TxHash,
 		DestAddr:         xmrAddr,
@@ -81,14 +81,14 @@ func TestSwapState_handleEvent_EventETHClaimed(t *testing.T) {
 	}
 
 	// assert that ready() is called, setup contract watcher
-	ethHeader, err := backend.ETH().Raw().HeaderByNumber(backend.Ctx(), nil)
+	ethHeader, err := backend.ETHClient().Raw().HeaderByNumber(backend.Ctx(), nil)
 	require.NoError(t, err)
 	logReadyCh := make(chan ethtypes.Log)
 
 	readyTopic := common.GetTopic(common.ReadyEventSignature)
 	readyWatcher := watcher.NewEventFilter(
 		s.Backend.Ctx(),
-		s.Backend.ETH().Raw(),
+		s.Backend.ETHClient().Raw(),
 		s.Backend.ContractAddr(),
 		ethHeader.Number,
 		readyTopic,

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -44,7 +44,7 @@ type Config struct {
 func NewInstance(cfg *Config) (*Instance, error) {
 	// if this is set, it transfers all xmr received during swaps back to the given wallet.
 	if cfg.TransferBack {
-		cfg.Backend.SetBaseXMRDepositAddress(cfg.Backend.XMR().PrimaryWalletAddress())
+		cfg.Backend.SetBaseXMRDepositAddress(cfg.Backend.XMRClient().PrimaryWalletAddress())
 	}
 
 	return &Instance{

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -187,22 +187,23 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 		return fmt.Errorf("address received in message does not match expected address")
 	}
 
-	s.XMR().Lock()
-	defer s.XMR().Unlock()
+	s.XMRClient().Lock()
+	defer s.XMRClient().Unlock()
 
 	t := time.Now().Format(common.TimeFmtNSecs)
 	walletName := fmt.Sprintf("xmrtaker-viewonly-wallet-%s", t)
-	if err := s.XMR().GenerateViewOnlyWalletFromKeys(vk, lockedAddr, s.walletScanHeight, walletName, ""); err != nil {
+	err := s.XMRClient().GenerateViewOnlyWalletFromKeys(vk, lockedAddr, s.walletScanHeight, walletName, "")
+	if err != nil {
 		return fmt.Errorf("failed to generate view-only wallet to verify locked XMR: %w", err)
 	}
 
 	log.Debugf("generated view-only wallet to check funds: %s", walletName)
 
-	if err := s.XMR().Refresh(); err != nil {
+	if err = s.XMRClient().Refresh(); err != nil {
 		return fmt.Errorf("failed to refresh client: %w", err)
 	}
 
-	balance, err := s.XMR().GetBalance(0)
+	balance, err := s.XMRClient().GetBalance(0)
 	if err != nil {
 		return fmt.Errorf("failed to get balance: %w", err)
 	}
@@ -227,7 +228,7 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 			balance.BlocksToUnlock)
 	}
 
-	if err = s.XMR().CloseWallet(); err != nil {
+	if err = s.XMRClient().CloseWallet(); err != nil {
 		return fmt.Errorf("failed to close wallet: %w", err)
 	}
 
@@ -255,7 +256,7 @@ func (s *swapState) runT1ExpirationHandler() {
 
 	waitCh := make(chan error)
 	go func() {
-		waitCh <- s.ETH().WaitForTimestamp(waitCtx, s.t1)
+		waitCh <- s.ETHClient().WaitForTimestamp(waitCtx, s.t1)
 		close(waitCh)
 	}()
 

--- a/protocol/xmrtaker/net.go
+++ b/protocol/xmrtaker/net.go
@@ -36,24 +36,24 @@ func (a *Instance) initiate(providesAmount common.EtherAmount, receivedAmount co
 		return nil, errProtocolAlreadyInProgress
 	}
 
-	balance, err := a.backend.ETH().Balance(a.backend.Ctx())
+	balance, err := a.backend.ETHClient().Balance(a.backend.Ctx())
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure the user's balance is strictly greater than the amount they will provide
 	if ethAsset == types.EthAssetETH && balance.Cmp(providesAmount.BigInt()) <= 0 {
-		log.Warnf("Account %s needs additional funds for this transaction", a.backend.ETH().Address())
+		log.Warnf("Account %s needs additional funds for this transaction", a.backend.ETHClient().Address())
 		return nil, errBalanceTooLow
 	}
 
 	if ethAsset != types.EthAssetETH {
-		erc20Contract, err := contracts.NewIERC20(ethAsset.Address(), a.backend.ETH().Raw()) //nolint:govet
+		erc20Contract, err := contracts.NewIERC20(ethAsset.Address(), a.backend.ETHClient().Raw()) //nolint:govet
 		if err != nil {
 			return nil, err
 		}
 
-		balance, err := erc20Contract.BalanceOf(a.backend.ETH().CallOpts(a.backend.Ctx()), a.backend.ETH().Address())
+		balance, err := erc20Contract.BalanceOf(a.backend.ETHClient().CallOpts(a.backend.Ctx()), a.backend.ETHClient().Address()) //nolint:lll
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/xmrtaker/recovery.go
+++ b/protocol/xmrtaker/recovery.go
@@ -127,7 +127,7 @@ func (rs *recoveryState) ClaimOrRefund() (*RecoveryResult, error) {
 func (s *swapState) filterForClaim() (*mcrypto.PrivateSpendKey, error) {
 	const claimedEvent = "Claimed"
 
-	logs, err := s.ETH().Raw().FilterLogs(s.ctx, eth.FilterQuery{
+	logs, err := s.ETHClient().Raw().FilterLogs(s.ctx, eth.FilterQuery{
 		Addresses: []ethcommon.Address{s.ContractAddr()},
 		Topics:    [][]ethcommon.Hash{{claimedTopic}},
 	})

--- a/protocol/xmrtaker/recovery_test.go
+++ b/protocol/xmrtaker/recovery_test.go
@@ -23,7 +23,7 @@ func newTestRecoveryState(t *testing.T, timeout time.Duration) *recoveryState {
 	s.dleqProof = akp.DLEqProof
 
 	s.setXMRMakerKeys(s.pubkeys.SpendKey(), s.privkeys.ViewKey(), akp.Secp256k1PublicKey)
-	s.xmrmakerAddress = s.ETH().Address()
+	s.xmrmakerAddress = s.ETHClient().Address()
 
 	_, err = s.lockAsset(common.NewEtherAmount(1))
 	require.NoError(t, err)
@@ -45,12 +45,12 @@ func TestClaimOrRefund_Claim(t *testing.T) {
 
 	// call swap.Claim()
 	sc := rs.ss.getSecret()
-	txOpts, err := rs.ss.ETH().TxOpts(rs.ss.ctx)
+	txOpts, err := rs.ss.ETHClient().TxOpts(rs.ss.ctx)
 	require.NoError(t, err)
 
 	tx, err := rs.ss.Contract().Claim(txOpts, rs.ss.contractSwap, sc)
 	require.NoError(t, err)
-	tests.MineTransaction(t, rs.ss.ETH().Raw(), tx)
+	tests.MineTransaction(t, rs.ss.ETHClient().Raw(), tx)
 	t.Log("XMRMaker claimed ETH...")
 
 	// assert we can claim the monero

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -116,13 +116,13 @@ func newSwapState(b backend.Backend, offerID types.Hash, infofile string, transf
 		return nil, err
 	}
 
-	if !b.ETH().HasPrivateKey() {
+	if !b.ETHClient().HasPrivateKey() {
 		transferBack = true // front-end must set final deposit address
 	}
 
 	var sender txsender.Sender
 	if ethAsset != types.EthAssetETH {
-		erc20Contract, err := contracts.NewIERC20(ethAsset.Address(), b.ETH().Raw()) //nolint:govet
+		erc20Contract, err := contracts.NewIERC20(ethAsset.Address(), b.ETHClient().Raw()) //nolint:govet
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +138,7 @@ func newSwapState(b backend.Backend, offerID types.Hash, infofile string, transf
 		}
 	}
 
-	walletScanHeight, err := b.XMR().GetChainHeight()
+	walletScanHeight, err := b.XMRClient().GetChainHeight()
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func newSwapState(b backend.Backend, offerID types.Hash, infofile string, transf
 		walletScanHeight -= monero.MinSpendConfirmations
 	}
 
-	ethHeader, err := b.ETH().Raw().HeaderByNumber(b.Ctx(), nil)
+	ethHeader, err := b.ETHClient().Raw().HeaderByNumber(b.Ctx(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func newSwapState(b backend.Backend, offerID types.Hash, infofile string, transf
 
 	claimedWatcher := watcher.NewEventFilter(
 		ctx,
-		b.ETH().Raw(),
+		b.ETHClient().Raw(),
 		b.ContractAddr(),
 		ethHeader.Number,
 		claimedTopic,
@@ -371,7 +371,7 @@ func (s *swapState) doRefund() (ethcommon.Hash, error) {
 }
 
 func (s *swapState) tryRefund() (ethcommon.Hash, error) {
-	stage, err := s.Contract().Swaps(s.ETH().CallOpts(s.ctx), s.contractSwapID)
+	stage, err := s.Contract().Swaps(s.ETHClient().CallOpts(s.ctx), s.contractSwapID)
 	if err != nil {
 		return ethcommon.Hash{}, err
 	}
@@ -389,7 +389,7 @@ func (s *swapState) tryRefund() (ethcommon.Hash, error) {
 
 	isReady := stage == contracts.StageReady
 
-	ts, err := s.ETH().LatestBlockTimestamp(s.ctx)
+	ts, err := s.ETHClient().LatestBlockTimestamp(s.ctx)
 	if err != nil {
 		return ethcommon.Hash{}, err
 	}
@@ -478,12 +478,12 @@ func (s *swapState) setXMRMakerKeys(sk *mcrypto.PublicKey, vk *mcrypto.PrivateVi
 }
 
 func (s *swapState) approveToken() error {
-	token, err := contracts.NewIERC20(s.ethAsset.Address(), s.ETH().Raw())
+	token, err := contracts.NewIERC20(s.ethAsset.Address(), s.ETHClient().Raw())
 	if err != nil {
 		return fmt.Errorf("failed to instantiate IERC20: %w", err)
 	}
 
-	balance, err := token.BalanceOf(s.ETH().CallOpts(s.ctx), s.ETH().Address())
+	balance, err := token.BalanceOf(s.ETHClient().CallOpts(s.ctx), s.ETHClient().Address())
 	if err != nil {
 		return fmt.Errorf("failed to get balance for token: %w", err)
 	}
@@ -558,7 +558,7 @@ func (s *swapState) lockAsset(amount common.EtherAmount) (ethcommon.Hash, error)
 	s.setTimeouts(t0, t1)
 
 	s.contractSwap = contracts.SwapFactorySwap{
-		Owner:        s.ETH().Address(),
+		Owner:        s.ETHClient().Address(),
 		Claimer:      s.xmrmakerAddress,
 		PubKeyClaim:  cmtXMRMaker,
 		PubKeyRefund: cmtXMRTaker,
@@ -580,7 +580,7 @@ func (s *swapState) lockAsset(amount common.EtherAmount) (ethcommon.Hash, error)
 // call Claim(). Ready() should only be called once XMRTaker sees XMRMaker lock his XMR.
 // If time t_0 has passed, there is no point of calling Ready().
 func (s *swapState) ready() error {
-	stage, err := s.Contract().Swaps(s.ETH().CallOpts(s.ctx), s.contractSwapID)
+	stage, err := s.Contract().Swaps(s.ETHClient().CallOpts(s.ctx), s.contractSwapID)
 	if err != nil {
 		return err
 	}
@@ -633,10 +633,10 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 		return "", err
 	}
 
-	s.XMR().Lock()
-	defer s.XMR().Unlock()
+	s.XMRClient().Lock()
+	defer s.XMRClient().Unlock()
 
-	addr, err := monero.CreateWallet("xmrtaker-swap-wallet", s.Env(), s.Backend.XMR(), kpAB, s.walletScanHeight)
+	addr, err := monero.CreateWallet("xmrtaker-swap-wallet", s.Env(), s.Backend.XMRClient(), kpAB, s.walletScanHeight)
 	if err != nil {
 		return "", err
 	}
@@ -666,7 +666,7 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 		return "", fmt.Errorf("failed to wait for balance to unlock: %w", err)
 	}
 
-	_, err = s.XMR().SweepAll(depositAddr, 0)
+	_, err = s.XMRClient().SweepAll(depositAddr, 0)
 	if err != nil {
 		return "", fmt.Errorf("failed to send funds to original account: %w", err)
 	}
@@ -682,7 +682,7 @@ func (s *swapState) waitUntilBalanceUnlocks() error {
 		}
 
 		log.Infof("checking if balance unlocked...")
-		balance, err := s.XMR().GetBalance(0)
+		balance, err := s.XMRClient().GetBalance(0)
 		if err != nil {
 			return fmt.Errorf("failed to get balance: %w", err)
 		}
@@ -690,7 +690,7 @@ func (s *swapState) waitUntilBalanceUnlocks() error {
 		if balance.Balance == balance.UnlockedBalance {
 			return nil
 		}
-		if _, err = monero.WaitForBlocks(s.ctx, s.XMR(), int(balance.BlocksToUnlock)); err != nil {
+		if _, err = monero.WaitForBlocks(s.ctx, s.XMRClient(), int(balance.BlocksToUnlock)); err != nil {
 			log.Warnf("Waiting for %d monero blocks failed: %s", balance.BlocksToUnlock, err)
 		}
 	}

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -111,19 +111,19 @@ func newTestInstance(t *testing.T) *swapState {
 func newTestInstanceWithERC20(t *testing.T, initialBalance *big.Int) (*swapState, *contracts.ERC20Mock) {
 	b := newBackend(t)
 
-	txOpts, err := b.ETH().TxOpts(b.Ctx())
+	txOpts, err := b.ETHClient().TxOpts(b.Ctx())
 	require.NoError(t, err)
 
 	_, tx, contract, err := contracts.DeployERC20Mock(
 		txOpts,
-		b.ETH().Raw(),
+		b.ETHClient().Raw(),
 		"Mock",
 		"MOCK",
-		b.ETH().Address(),
+		b.ETHClient().Address(),
 		initialBalance,
 	)
 	require.NoError(t, err)
-	addr, err := bind.WaitDeployed(b.Ctx(), b.ETH().Raw(), tx)
+	addr, err := bind.WaitDeployed(b.Ctx(), b.ETHClient().Raw(), tx)
 	require.NoError(t, err)
 
 	swapState, err := newSwapState(b, types.Hash{}, infofile, false,
@@ -284,7 +284,7 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 	}
 
 	// check balance of contract is 0
-	balance, err := s.ETH().Raw().BalanceAt(context.Background(), s.ContractAddr(), nil)
+	balance, err := s.ETHClient().Raw().BalanceAt(context.Background(), s.ContractAddr(), nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), balance.Uint64())
 }
@@ -381,7 +381,7 @@ func TestSwapState_ApproveToken(t *testing.T) {
 	s, contract := newTestInstanceWithERC20(t, initialBalance)
 	err := s.approveToken()
 	require.NoError(t, err)
-	allowance, err := contract.Allowance(&bind.CallOpts{}, s.ETH().Address(), s.ContractAddr())
+	allowance, err := contract.Allowance(&bind.CallOpts{}, s.ETHClient().Address(), s.ContractAddr())
 	require.NoError(t, err)
 	require.Equal(t, initialBalance, allowance)
 }

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -190,6 +190,6 @@ func (*mockProtocolBackend) ClearXMRDepositAddress(types.Hash) {
 	panic("not implemented")
 }
 
-func (*mockProtocolBackend) ETH() extethclient.EthClient {
+func (*mockProtocolBackend) ETHClient() extethclient.EthClient {
 	panic("not implemented")
 }

--- a/rpc/personal.go
+++ b/rpc/personal.go
@@ -43,7 +43,7 @@ type SetGasPriceRequest struct {
 
 // SetGasPrice sets the gas price (in wei) to be used for ethereum transactions.
 func (s *PersonalService) SetGasPrice(_ *http.Request, req *SetGasPriceRequest, _ *interface{}) error {
-	s.pb.ETH().SetGasPrice(req.GasPrice)
+	s.pb.ETHClient().SetGasPrice(req.GasPrice)
 	return nil
 }
 
@@ -55,7 +55,7 @@ func (s *PersonalService) Balances(_ *http.Request, _ *interface{}, resp *rpctyp
 		return err
 	}
 
-	eBal, err := s.pb.ETH().Balance(s.ctx)
+	eBal, err := s.pb.ETHClient().Balance(s.ctx)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func (s *PersonalService) Balances(_ *http.Request, _ *interface{}, resp *rpctyp
 		PiconeroBalance:         mBal.Balance,
 		PiconeroUnlockedBalance: mBal.UnlockedBalance,
 		BlocksToUnlock:          mBal.BlocksToUnlock,
-		EthAddress:              s.pb.ETH().Address().String(),
+		EthAddress:              s.pb.ETHClient().Address().String(),
 		WeiBalance:              eBal,
 	}
 	return nil

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -156,7 +156,7 @@ type ProtocolBackend interface {
 	SwapManager() swap.Manager
 	SetXMRDepositAddress(mcrypto.Address, types.Hash)
 	ClearXMRDepositAddress(types.Hash)
-	ETH() extethclient.EthClient
+	ETHClient() extethclient.EthClient
 }
 
 // XMRTaker ...

--- a/rpc/ws.go
+++ b/rpc/ws.go
@@ -166,7 +166,7 @@ func (s *wsServer) handleSigner(ctx context.Context, conn *websocket.Conn, offer
 		return err
 	}
 
-	s.backend.ETH().SetAddress(ethcommon.HexToAddress(ethAddress))
+	s.backend.ETHClient().SetAddress(ethcommon.HexToAddress(ethAddress))
 	s.backend.SetXMRDepositAddress(mcrypto.Address(xmrAddr), offerID)
 	defer s.backend.ClearXMRDepositAddress(offerID)
 


### PR DESCRIPTION
This PR isn't for merging into the `dimalinux/rework-backend-wallet-interfaces` branch, not directly into `master`. Look at the diffs and see which one you like best.