### PR TITLE
reduce monero wallet contention

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -390,9 +390,9 @@ func runBalances(ctx *cli.Context) error {
 	fmt.Printf("ETH Balance: %s\n", balances.WeiBalance.AsEther().Text('f'))
 	fmt.Println()
 	fmt.Printf("Monero address: %s\n", balances.MoneroAddress)
-	fmt.Printf("XMR Balance: %s\n", balances.PiconeroBalance.AsMonero().Text('f'))
+	fmt.Printf("XMR Balance: %s\n", balances.PiconeroBalance.AsMoneroString())
 	fmt.Printf("Unlocked XMR balance: %s\n",
-		balances.PiconeroUnlockedBalance.AsMonero().Text('f'))
+		balances.PiconeroUnlockedBalance.AsMoneroString())
 	fmt.Printf("Blocks to unlock: %d\n", balances.BlocksToUnlock)
 	return nil
 }

--- a/cmd/swapd/main_test.go
+++ b/cmd/swapd/main_test.go
@@ -90,9 +90,9 @@ func TestDaemon_DevXMRTaker(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
+		defer wg.Done()
 		err := d.make(c) // blocks on RPC server start
 		require.ErrorIs(t, err, context.Canceled)
-		wg.Done()
 	}()
 	time.Sleep(500 * time.Millisecond) // let the server start
 	cancel()

--- a/cmd/swapd/main_test.go
+++ b/cmd/swapd/main_test.go
@@ -168,6 +168,8 @@ func TestDaemon_PersistOffers(t *testing.T) {
 	wc := monero.CreateWalletClientWithWalletDir(t, dataDir)
 	one := apd.New(1, 0)
 	monero.MineMinXMRBalance(t, wc, coins.MoneroToPiconero(one))
+	walletName := wc.WalletName()
+	wc.Close() // wallet file stays in place with mined monero
 
 	c := newTestContext(t,
 		"test --dev-xmrmaker",
@@ -178,7 +180,7 @@ func TestDaemon_PersistOffers(t *testing.T) {
 			flagRPCPort:          uint(0),
 			flagLibp2pPort:       uint(0),
 			flagDataDir:          dataDir,
-			flagMoneroWalletPath: path.Join(dataDir, "test-wallet"),
+			flagMoneroWalletPath: path.Join(dataDir, walletName),
 		},
 	)
 

--- a/coins/coins.go
+++ b/coins/coins.go
@@ -105,6 +105,14 @@ func (a *PiconeroAmount) AsMonero() *apd.Decimal {
 	return xmrAmt
 }
 
+// AsMoneroString converts a PiconeroAmount into a formatted XMR amount string.
+func (a *PiconeroAmount) AsMoneroString() string {
+	xmrAmt := new(apd.Decimal).Set(a.Decimal())
+	decreaseExponent(xmrAmt, NumMoneroDecimals)
+	_, _ = xmrAmt.Reduce(xmrAmt)
+	return xmrAmt.Text('f')
+}
+
 // FmtPiconeroAmtAsXMR takes piconeros as input and produces a formatted string of the
 // amount in XMR.
 func FmtPiconeroAmtAsXMR(piconeros uint64) string {

--- a/coins/coins.go
+++ b/coins/coins.go
@@ -107,16 +107,13 @@ func (a *PiconeroAmount) AsMonero() *apd.Decimal {
 
 // AsMoneroString converts a PiconeroAmount into a formatted XMR amount string.
 func (a *PiconeroAmount) AsMoneroString() string {
-	xmrAmt := new(apd.Decimal).Set(a.Decimal())
-	decreaseExponent(xmrAmt, NumMoneroDecimals)
-	_, _ = xmrAmt.Reduce(xmrAmt)
-	return xmrAmt.Text('f')
+	return a.AsMonero().Text('f')
 }
 
 // FmtPiconeroAmtAsXMR takes piconeros as input and produces a formatted string of the
 // amount in XMR.
 func FmtPiconeroAmtAsXMR(piconeros uint64) string {
-	return NewPiconeroAmount(piconeros).AsMonero().Text('f')
+	return NewPiconeroAmount(piconeros).AsMoneroString()
 }
 
 // WeiAmount represents some amount of ether in the smallest denomination (wei)

--- a/coins/coins.go
+++ b/coins/coins.go
@@ -105,6 +105,12 @@ func (a *PiconeroAmount) AsMonero() *apd.Decimal {
 	return xmrAmt
 }
 
+// FmtPiconeroAmtAsXMR takes piconeros as input and produces a formatted string of the
+// amount in XMR.
+func FmtPiconeroAmtAsXMR(piconeros uint64) string {
+	return NewPiconeroAmount(piconeros).AsMonero().Text('f')
+}
+
 // WeiAmount represents some amount of ether in the smallest denomination (wei)
 type WeiAmount apd.Decimal
 

--- a/coins/coins_test.go
+++ b/coins/coins_test.go
@@ -18,7 +18,7 @@ func TestPiconeroAmount(t *testing.T) {
 
 	amount := StrToDecimal(preciseAmount)
 	piconero := MoneroToPiconero(amount)
-	assert.Equal(t, moneroAmount, piconero.AsMonero().String())
+	assert.Equal(t, moneroAmount, piconero.AsMoneroString())
 	assert.Equal(t, piconeroAmount, piconero.String())
 }
 

--- a/crypto/monero/crypto.go
+++ b/crypto/monero/crypto.go
@@ -27,7 +27,8 @@ type PrivateKeyPair struct {
 }
 
 // NewPrivateKeyPair returns a new PrivateKeyPair from the given PrivateSpendKey and PrivateViewKey.
-// It does not validate if the view key corresponds to the spend key.
+// Both values must be set, as no assumptions are made that the view key is derived from the spend
+// key with this type.
 func NewPrivateKeyPair(sk *PrivateSpendKey, vk *PrivateViewKey) *PrivateKeyPair {
 	return &PrivateKeyPair{
 		sk: sk,

--- a/monero/test_support.go
+++ b/monero/test_support.go
@@ -60,10 +60,8 @@ func CreateWalletClient(t *testing.T) WalletClient {
 }
 
 // GetBalance is a convenience method for tests that assumes you want the primary
-// address, that you want to refresh, and that errors should fail the test.
+// address and that errors should fail the test.
 func GetBalance(t *testing.T, wc WalletClient) *wallet.GetBalanceResponse {
-	err := wc.Refresh()
-	require.NoError(t, err)
 	balance, err := wc.GetBalance(0)
 	require.NoError(t, err)
 	return balance
@@ -127,7 +125,6 @@ func MineMinXMRBalance(t *testing.T, wc WalletClient, minBalance *coins.Piconero
 	require.NoError(t, err)
 
 	for {
-		require.NoError(t, wc.Refresh())
 		balance, err := wc.GetBalance(0)
 		require.NoError(t, err)
 		if balance.UnlockedBalance > minBalU64 {

--- a/monero/utils.go
+++ b/monero/utils.go
@@ -37,7 +37,7 @@ func WaitForBlocks(ctx context.Context, client WalletClient, count int) (uint64,
 
 		if height >= endHeight {
 			// ensure wallet height is refreshed to the chain height
-			if err = client.(*walletClient).refresh(); err != nil {
+			if err = c.refresh(); err != nil {
 				return 0, err
 			}
 			return height, nil

--- a/monero/utils.go
+++ b/monero/utils.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/athanorlabs/atomic-swap/common"
-	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
-
 	logging "github.com/ipfs/go-log"
+
+	"github.com/athanorlabs/atomic-swap/common"
 )
 
 var (
@@ -52,31 +51,4 @@ func WaitForBlocks(ctx context.Context, client WalletClient, count int) (uint64,
 			return 0, err
 		}
 	}
-}
-
-// CreateWallet creates a monero wallet from a private keypair.
-func CreateWallet(
-	name string,
-	env common.Environment,
-	client WalletClient,
-	kpAB *mcrypto.PrivateKeyPair,
-	restoreHeight uint64,
-) (WalletClient, error) {
-	conf := client.CreateABWalletConf()
-	abCli, err := CreateSpendWalletFromKeys(conf, kpAB, restoreHeight)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = abCli.Refresh(); err != nil {
-		return nil, err
-	}
-
-	balance, err := abCli.GetBalance(0)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Info("wallet balance: ", balance.Balance)
-	return abCli, nil
 }

--- a/monero/utils_test.go
+++ b/monero/utils_test.go
@@ -2,13 +2,9 @@ package monero
 
 import (
 	"context"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/athanorlabs/atomic-swap/common"
-	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
 )
 
 func TestWaitForBlocks(t *testing.T) {
@@ -20,25 +16,4 @@ func TestWaitForBlocks(t *testing.T) {
 	heightAfter, err := WaitForBlocks(context.Background(), c, 2)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, heightAfter-heightBefore, uint64(2))
-}
-
-func TestCreateWalletFromKeys(t *testing.T) {
-	c, err := NewWalletClient(&WalletClientConf{
-		Env:                 common.Development,
-		WalletFilePath:      path.Join(t.TempDir(), "wallet", "not-used"),
-		MoneroWalletRPCPath: moneroWalletRPCPath,
-	})
-	require.NoError(t, err)
-	defer c.Close()
-
-	height, err := c.GetHeight()
-	require.NoError(t, err)
-
-	kp, err := mcrypto.GenerateKeys()
-	require.NoError(t, err)
-
-	conf := c.CreateABWalletConf()
-	abCli, err := CreateSpendWalletFromKeys(conf, kp, height)
-	require.NoError(t, err)
-	require.Equal(t, kp.Address(common.Development), abCli.PrimaryAddress())
 }

--- a/monero/utils_test.go
+++ b/monero/utils_test.go
@@ -22,21 +22,23 @@ func TestWaitForBlocks(t *testing.T) {
 	require.GreaterOrEqual(t, heightAfter-heightBefore, uint64(2))
 }
 
-func TestCreateMoneroWallet(t *testing.T) {
-	kp, err := mcrypto.GenerateKeys()
-	require.NoError(t, err)
-
+func TestCreateWalletFromKeys(t *testing.T) {
 	c, err := NewWalletClient(&WalletClientConf{
 		Env:                 common.Development,
 		WalletFilePath:      path.Join(t.TempDir(), "wallet", "not-used"),
 		MoneroWalletRPCPath: moneroWalletRPCPath,
 	})
 	require.NoError(t, err)
+	defer c.Close()
 
 	height, err := c.GetHeight()
 	require.NoError(t, err)
 
-	addr, err := CreateWallet("create-wallet-test", common.Development, c, kp, height)
+	kp, err := mcrypto.GenerateKeys()
 	require.NoError(t, err)
-	require.Equal(t, kp.Address(common.Development), addr)
+
+	conf := c.CreateABWalletConf()
+	abCli, err := CreateSpendWalletFromKeys(conf, kp, height)
+	require.NoError(t, err)
+	require.Equal(t, kp.Address(common.Development), abCli.PrimaryAddress())
 }

--- a/monero/utils_test.go
+++ b/monero/utils_test.go
@@ -10,7 +10,7 @@ import (
 func TestWaitForBlocks(t *testing.T) {
 	c := CreateWalletClient(t)
 
-	heightBefore, err := c.GetChainHeight()
+	heightBefore, err := c.GetHeight()
 	require.NoError(t, err)
 
 	heightAfter, err := WaitForBlocks(context.Background(), c, 2)

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -412,8 +412,8 @@ func createWalletFromKeys(
 	c.walletAddr = mcrypto.Address(acctResp.Address)
 	if c.walletAddr != address {
 		c.Close()
-		log.Errorf("Provided address %s does not match wallet computed address %s", address, c.walletAddr)
-		return nil, errors.New("monero address mismatch")
+		return nil, fmt.Errorf("provided address %s does not match monero-wallet-rpc computed address %s",
+			address, c.walletAddr)
 	}
 
 	bal, err := c.GetBalance(0)

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -43,7 +43,7 @@ type WalletClient interface {
 	Transfer(to mcrypto.Address, accountIdx uint64, amount *coins.PiconeroAmount) (*wallet.TransferResponse, error)
 	SweepAll(to mcrypto.Address, accountIdx uint64) (*wallet.SweepAllResponse, error)
 	WaitForReceipt(req *WaitForReceiptRequest) (*wallet.Transfer, error)
-	CreateABWalletConf() *WalletClientConf
+	CreateABWalletConf(walletNamePrefix string) *WalletClientConf
 	WalletName() string
 	GetHeight() (uint64, error)
 	GetChainHeight() (uint64, error)
@@ -262,8 +262,8 @@ func (c *walletClient) SweepAll(to mcrypto.Address, accountIdx uint64) (*wallet.
 	})
 }
 
-func (c *walletClient) CreateABWalletConf() *WalletClientConf {
-	walletName := fmt.Sprintf("ab-swap-wallet-%s", time.Now().Format(common.TimeFmtNSecs))
+func (c *walletClient) CreateABWalletConf(walletNamePrefix string) *WalletClientConf {
+	walletName := fmt.Sprintf("%s-%s", walletNamePrefix, time.Now().Format(common.TimeFmtNSecs))
 	walletPath := path.Join(path.Dir(c.conf.WalletFilePath), walletName)
 	conf := &WalletClientConf{
 		Env:                 c.conf.Env,

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -32,6 +32,10 @@ const (
 	// MinSpendConfirmations is the number of confirmations required on transaction
 	// outputs before they can be spent again.
 	MinSpendConfirmations = 10
+
+	// SweepToSelfConfirmations is the number of confirmations that we wait for when
+	// sweeping funds from an A+B wallet to our primary wallet.
+	SweepToSelfConfirmations = 2
 )
 
 // WalletClient represents a monero-wallet-rpc client.

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -416,7 +416,9 @@ func createWalletFromKeys(
 	}
 	c.walletAddr = mcrypto.Address(acctResp.Address)
 	if c.walletAddr != address {
-		panic("addresses do not match")
+		c.Close()
+		log.Errorf("Provided address %s does not match wallet computed address %s", address, c.walletAddr)
+		return nil, errors.New("monero address mismatch")
 	}
 
 	bal, err := c.GetBalance(0)

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -393,6 +393,7 @@ func createWalletFromKeys(
 	if err != nil {
 		return nil, err
 	}
+
 	c := NewThinWalletClient(monerodNode.Host, monerodNode.Port, conf.WalletPort).(*walletClient)
 	c.rpcProcess = proc
 	c.conf = conf
@@ -408,6 +409,7 @@ func createWalletFromKeys(
 		c.Close()
 		return nil, err
 	}
+
 	acctResp, err := c.GetAddress(0)
 	if err != nil {
 		c.Close()
@@ -531,10 +533,12 @@ func (c *walletClient) GetHeight() (uint64, error) {
 	if err := c.refresh(); err != nil {
 		return 0, err
 	}
+
 	res, err := c.wRPC.GetHeight()
 	if err != nil {
 		return 0, err
 	}
+
 	return res.Height, nil
 }
 
@@ -545,6 +549,7 @@ func (c *walletClient) getChainHeight() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return res.Count, nil
 }
 
@@ -600,6 +605,7 @@ func findWorkingNode(env common.Environment, nodes []*common.MoneroNode) (*commo
 	if len(nodes) == 0 {
 		return nil, errors.New("no monero nodes")
 	}
+
 	var err error
 	for _, n := range nodes {
 		err = validateMonerodNode(env, n)
@@ -609,6 +615,7 @@ func findWorkingNode(env common.Environment, nodes []*common.MoneroNode) (*commo
 		}
 		return n, nil
 	}
+
 	// err is non-nil if we get here
 	return nil, fmt.Errorf("failed to validate any monerod RPC node, last error: %w", err)
 }
@@ -618,10 +625,12 @@ func findWorkingNode(env common.Environment, nodes []*common.MoneroNode) (*commo
 func validateMonerodNode(env common.Environment, node *common.MoneroNode) error {
 	endpoint := fmt.Sprintf("http://%s:%d/json_rpc", node.Host, node.Port)
 	daemonCli := monerorpc.New(endpoint, nil).Daemon
+
 	info, err := daemonCli.GetInfo()
 	if err != nil {
 		return fmt.Errorf("could not validate monerod endpoint %s: %w", endpoint, err)
 	}
+
 	switch env {
 	case common.Stagenet:
 		if !info.Stagenet {
@@ -639,12 +648,15 @@ func validateMonerodNode(env common.Environment, node *common.MoneroNode) error 
 	default:
 		panic("unhandled environment type")
 	}
+
 	if env != common.Development && info.Offline {
 		return fmt.Errorf("monerod endpoint %s is offline", endpoint)
 	}
+
 	if !info.Synchronized {
 		return fmt.Errorf("monerod endpoint %s is not synchronised", endpoint)
 	}
+
 	return nil
 }
 
@@ -659,7 +671,6 @@ func createWalletRPCService(
 	logFilePath string,
 	moneroNode *common.MoneroNode,
 ) (*os.Process, error) {
-
 	walletRPCBinArgs := getWalletRPCFlags(env, walletPort, walletDir, logFilePath, moneroNode)
 	proc, err := launchMoneroWalletRPCChild(walletRPCBinPath, walletRPCBinArgs...)
 	if err != nil {
@@ -741,10 +752,12 @@ func launchMoneroWalletRPCChild(walletRPCBin string, walletRPCBinArgs ...string)
 			break
 		}
 	}
+
 	if !started {
 		_, _ = cmd.Process.Wait() // shouldn't block, process already exited
 		return nil, errors.New("failed to start monero-wallet-rpc")
 	}
+
 	time.Sleep(200 * time.Millisecond) // additional start time
 
 	// Drain additional output. We are not detaching monero-wallet-rpc so it will
@@ -758,6 +771,7 @@ func launchMoneroWalletRPCChild(walletRPCBin string, walletRPCBinArgs ...string)
 		}
 		log.Warnf("monero-wallet-rpc pid=%d exited", cmd.Process.Pid)
 	}()
+
 	return cmd.Process, nil
 }
 
@@ -800,9 +814,10 @@ func getWalletRPCFlags(
 // allocated ports are randomised to make the risk negligible.
 func getFreeTCPPort() (uint, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	defer func() { _ = ln.Close() }()
 	if err != nil {
 		return 0, err
 	}
+	defer func() { _ = ln.Close() }()
+
 	return uint(ln.Addr().(*net.TCPAddr).Port), nil
 }

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -62,7 +62,7 @@ type WalletClient interface {
 	GetHeight() (uint64, error)
 	GetChainHeight() (uint64, error)
 	Refresh() error
-	CreateWallet(filename, password string) error
+
 	OpenWallet(filename, password string) error
 	CloseWallet() error
 	Endpoint() string // URL on which the wallet is accepting RPC requests

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -216,9 +216,7 @@ func (c *walletClient) waitForReceipt(req *waitForReceiptRequest) (*wallet.Trans
 	var transfer *wallet.Transfer
 
 	for {
-		if err = c.refresh(); err != nil {
-			return nil, err
-		}
+		// Wallet is already refreshed here, due to GetHeight above and WaitForBlocks below
 		transferResp, err := c.wRPC.GetTransferByTxid(&wallet.GetTransferByTxidRequest{
 			TxID:         req.TxID,
 			AccountIndex: req.AccountIdx,
@@ -415,12 +413,6 @@ func createWalletFromKeys(
 	c.walletAddr = mcrypto.Address(acctResp.Address)
 	if c.walletAddr != address {
 		panic("addresses do not match")
-	}
-
-	err = c.refresh()
-	if err != nil {
-		c.Close()
-		return nil, err
 	}
 
 	bal, err := c.GetBalance(0)

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -280,7 +280,6 @@ func (c *walletClient) Transfer(
 		NumConfirmations: numConfirmations,
 		AccountIdx:       accountIdx,
 	})
-	log.Warnf("Transfer TXID=%s failed to get receipt: %s", reqResp.TxHash, err)
 	if err != nil {
 		return nil, fmt.Errorf("monero TXID=%s receipt failure: %w", reqResp.TxHash, err)
 	}

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -433,7 +433,7 @@ func createWalletFromKeys(
 		bal.BlocksToUnlock,
 		c.PrimaryAddress(),
 	)
-	return c, err
+	return c, nil
 }
 
 // CreateSpendWalletFromKeys creates a new monero-wallet-rpc process and wallet from a given wallet address,

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -57,7 +57,7 @@ type WalletClient interface {
 		accountIdx uint64,
 		numConfirmations uint64,
 	) ([]*wallet.Transfer, error)
-	CreateABWalletConf(walletNamePrefix string) *WalletClientConf
+	CreateWalletConf(walletNamePrefix string) *WalletClientConf
 	WalletName() string
 	GetHeight() (uint64, error)
 	Endpoint() string // URL on which the wallet is accepting RPC requests
@@ -351,7 +351,7 @@ func (c *walletClient) SweepAll(
 	return transfers, nil
 }
 
-func (c *walletClient) CreateABWalletConf(walletNamePrefix string) *WalletClientConf {
+func (c *walletClient) CreateWalletConf(walletNamePrefix string) *WalletClientConf {
 	walletName := fmt.Sprintf("%s-%s", walletNamePrefix, time.Now().Format(common.TimeFmtNSecs))
 	walletPath := path.Join(path.Dir(c.conf.WalletFilePath), walletName)
 	conf := &WalletClientConf{

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -431,8 +431,8 @@ func createWalletFromKeys(
 	return c, nil
 }
 
-// CreateSpendWalletFromKeys creates a new monero-wallet-rpc process and wallet from a given wallet address,
-// view key, and optional spend key
+// CreateSpendWalletFromKeys creates a new monero-wallet-rpc process, wallet client and
+// spend wallet for the passed private key pair (view key and spend key).
 func CreateSpendWalletFromKeys(
 	conf *WalletClientConf,
 	privateKeyPair *mcrypto.PrivateKeyPair,
@@ -444,7 +444,8 @@ func CreateSpendWalletFromKeys(
 	return createWalletFromKeys(conf, restoreHeight, privateSpendKey, privateViewKey, address)
 }
 
-// CreateViewOnlyWalletFromKeys creates a view-only wallet from a given view key and address
+// CreateViewOnlyWalletFromKeys creates a new monero-wallet-rpc process, wallet client and
+// view-only wallet for the passed private view key and address.
 func CreateViewOnlyWalletFromKeys(
 	conf *WalletClientConf,
 	privateViewKey *mcrypto.PrivateViewKey,

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -65,9 +65,8 @@ type WalletClientConf struct {
 
 // WaitForReceiptRequest wraps the input parameters for WaitForReceipt
 type WaitForReceiptRequest struct {
-	Ctx  context.Context
-	TxID string
-	//DestAddr         mcrypto.Address
+	Ctx              context.Context
+	TxID             string
 	NumConfirmations uint64
 	AccountIdx       uint64
 }

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -310,21 +310,18 @@ func (c *walletClient) SweepAll(
 	if balance.BlocksToUnlock > 0 {
 		log.Infof("Sweep operation waiting %d blocks for balance to fully unlock", balance.BlocksToUnlock)
 		if _, err = WaitForBlocks(ctx, c, int(balance.BlocksToUnlock)); err != nil {
-			log.Warnf("Sweep operation from %s failed waiting to unlock balance", from)
 			return nil, fmt.Errorf("sweep operation failed waiting to unlock balance: %w", err)
 		}
 	}
 	if balance.Balance == 0 {
-		log.Warnf("Sweep operation from %s failed, no balance to sweep", from)
-		return nil, errors.New("no balance to sweep")
+		return nil, fmt.Errorf("sweep from %s failed, no balance to sweep", from)
 	}
 	reqResp, err := c.wRPC.SweepAll(&wallet.SweepAllRequest{
 		AccountIndex: accountIdx,
 		Address:      string(to),
 	})
 	if err != nil {
-		log.Warnf("Sweep transaction(s) from %s failed, %s", from, err)
-		return nil, fmt.Errorf("sweep_all failed: %w", err)
+		return nil, fmt.Errorf("sweep_all from %s failed: %w", from, err)
 	}
 	log.Infof("Sweep transaction started, TX IDs: %s", strings.Join(reqResp.TxHashList, ", "))
 	var transfers []*wallet.Transfer
@@ -336,8 +333,7 @@ func (c *walletClient) SweepAll(
 			AccountIdx:       accountIdx,
 		})
 		if err != nil {
-			log.Warnf("Sweep TX ID %s failed waiting for receipt: %s", txID, err)
-			return nil, fmt.Errorf("sweep failed waiting for receipt: %w", err)
+			return nil, fmt.Errorf("sweep of TXID=%s failed waiting for receipt: %w", txID, err)
 		}
 		log.Infof("Sweep transfer ID=%s of %s XMR (%s XMR fees) completed at height %d",
 			txID,

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -302,6 +302,7 @@ func (c *walletClient) SweepAll(
 		return nil, fmt.Errorf("sweep operation failed to get address: %w", err)
 	}
 	from := addrResp.Address
+
 	balance, err := c.GetBalance(accountIdx)
 	if err != nil {
 		return nil, fmt.Errorf("sweep operation failed to get balance: %w", err)
@@ -316,6 +317,7 @@ func (c *walletClient) SweepAll(
 			return nil, fmt.Errorf("sweep operation failed waiting to unlock balance: %w", err)
 		}
 	}
+
 	reqResp, err := c.wRPC.SweepAll(&wallet.SweepAllRequest{
 		AccountIndex: accountIdx,
 		Address:      string(to),
@@ -324,6 +326,7 @@ func (c *walletClient) SweepAll(
 		return nil, fmt.Errorf("sweep_all from %s failed: %w", from, err)
 	}
 	log.Infof("Sweep transaction started, TX IDs: %s", strings.Join(reqResp.TxHashList, ", "))
+
 	var transfers []*wallet.Transfer
 	for _, txID := range reqResp.TxHashList {
 		receipt, err := c.waitForReceipt(&waitForReceiptRequest{
@@ -343,6 +346,7 @@ func (c *walletClient) SweepAll(
 		)
 		transfers = append(transfers, receipt)
 	}
+
 	return transfers, nil
 }
 

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -307,14 +307,14 @@ func (c *walletClient) SweepAll(
 		return nil, fmt.Errorf("sweep operation failed to get balance: %w", err)
 	}
 	log.Infof("Starting sweep of %s XMR from %s to %s", coins.FmtPiconeroAmtAsXMR(balance.Balance), from, to)
+	if balance.Balance == 0 {
+		return nil, fmt.Errorf("sweep from %s failed, no balance to sweep", from)
+	}
 	if balance.BlocksToUnlock > 0 {
 		log.Infof("Sweep operation waiting %d blocks for balance to fully unlock", balance.BlocksToUnlock)
 		if _, err = WaitForBlocks(ctx, c, int(balance.BlocksToUnlock)); err != nil {
 			return nil, fmt.Errorf("sweep operation failed waiting to unlock balance: %w", err)
 		}
-	}
-	if balance.Balance == 0 {
-		return nil, fmt.Errorf("sweep from %s failed, no balance to sweep", from)
 	}
 	reqResp, err := c.wRPC.SweepAll(&wallet.SweepAllRequest{
 		AccountIndex: accountIdx,

--- a/monero/wallet_client_test.go
+++ b/monero/wallet_client_test.go
@@ -321,3 +321,24 @@ func Test_walletClient_waitForConfirmations_contextCancelled(t *testing.T) {
 	})
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestCreateWalletFromKeys(t *testing.T) {
+	c, err := NewWalletClient(&WalletClientConf{
+		Env:                 common.Development,
+		WalletFilePath:      path.Join(t.TempDir(), "wallet", "not-used"),
+		MoneroWalletRPCPath: moneroWalletRPCPath,
+	})
+	require.NoError(t, err)
+	defer c.Close()
+
+	height, err := c.GetHeight()
+	require.NoError(t, err)
+
+	kp, err := mcrypto.GenerateKeys()
+	require.NoError(t, err)
+
+	conf := c.CreateABWalletConf()
+	abCli, err := CreateSpendWalletFromKeys(conf, kp, height)
+	require.NoError(t, err)
+	require.Equal(t, kp.Address(common.Development), abCli.PrimaryAddress())
+}

--- a/monero/wallet_client_test.go
+++ b/monero/wallet_client_test.go
@@ -185,10 +185,9 @@ func TestClient_GetHeight(t *testing.T) {
 	require.NoError(t, err)
 	defer c.Close()
 
-	require.NoError(t, c.Refresh())
 	walletHeight, err := c.GetHeight()
 	require.NoError(t, err)
-	chainHeight, err := c.GetChainHeight()
+	chainHeight, err := c.(*walletClient).getChainHeight()
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, chainHeight, walletHeight)
 	require.LessOrEqual(t, chainHeight-walletHeight, uint64(2))

--- a/monero/wallet_client_test.go
+++ b/monero/wallet_client_test.go
@@ -74,7 +74,7 @@ func TestClient_Transfer(t *testing.T) {
 	alicePrimaryAddr := cXMRTaker.PrimaryAddress()
 
 	// Alice generates a view-only wallet for A+B to confirm that Bob sent the funds
-	conf := cXMRTaker.CreateABWalletConf("alice-view-wallet-to-verify-funds")
+	conf := cXMRTaker.CreateWalletConf("alice-view-wallet-to-verify-funds")
 	abViewCli, err := CreateViewOnlyWalletFromKeys(conf, vkABPriv, abAddress, transfer.Height)
 	require.NoError(t, err)
 	defer abViewCli.CloseAndRemoveWallet()
@@ -97,7 +97,7 @@ func TestClient_Transfer(t *testing.T) {
 		mcrypto.SumPrivateViewKeys(kpA.ViewKey(), kpB.ViewKey()),
 	)
 	require.NoError(t, err)
-	conf = abViewCli.CreateABWalletConf("alice-spend-wallet-to-claim")
+	conf = abViewCli.CreateWalletConf("alice-spend-wallet-to-claim")
 	abSpendCli, err := CreateSpendWalletFromKeys(conf, abWalletKeyPair, transfer.Height)
 	require.NoError(t, err)
 	defer abSpendCli.CloseAndRemoveWallet()
@@ -317,7 +317,7 @@ func TestCreateWalletFromKeys(t *testing.T) {
 	kp, err := mcrypto.GenerateKeys()
 	require.NoError(t, err)
 
-	conf := primaryCli.CreateABWalletConf("ab-wallet")
+	conf := primaryCli.CreateWalletConf("ab-wallet")
 	abCli, err := CreateSpendWalletFromKeys(conf, kp, height)
 	require.NoError(t, err)
 	defer abCli.CloseAndRemoveWallet()

--- a/monero/wallet_client_test.go
+++ b/monero/wallet_client_test.go
@@ -108,7 +108,7 @@ func TestClient_Transfer(t *testing.T) {
 	require.Equal(t, transferAmtU64, balanceABWal.UnlockedBalance)
 
 	// Alice transfers from A+B spend wallet to her primary wallet's address
-	transfers, err := abSpendCli.SweepAll(ctx, alicePrimaryAddr, 0, 2)
+	transfers, err := abSpendCli.SweepAll(ctx, alicePrimaryAddr, 0, SweepToSelfConfirmations)
 	require.NoError(t, err)
 	t.Logf("Alice swept AB wallet funds with %d transfers", len(transfers))
 	require.Len(t, transfers, 1) // In our case, it should always be a single transaction
@@ -141,7 +141,7 @@ func Test_walletClient_SweepAll_nothingToSweepReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	destAddr := mcrypto.Address(addrResp.Address)
 
-	_, err = emptyWallet.SweepAll(context.Background(), destAddr, 0, 1)
+	_, err = emptyWallet.SweepAll(context.Background(), destAddr, 0, SweepToSelfConfirmations)
 	require.ErrorContains(t, err, "no balance to sweep")
 }
 

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -22,7 +22,7 @@ type Manager interface {
 	GetPastIDs() ([]types.Hash, error)
 	GetPastSwap(types.Hash) (*Info, error)
 	GetOngoingSwap(types.Hash) (Info, error)
-	GetOngoingSwaps() ([]Info, error)
+	GetOngoingSwaps() ([]*Info, error)
 	CompleteOngoingSwap(info *Info) error
 }
 
@@ -148,13 +148,15 @@ func (m *manager) GetOngoingSwap(id types.Hash) (Info, error) {
 }
 
 // GetOngoingSwaps returns all ongoing swaps.
-func (m *manager) GetOngoingSwaps() ([]Info, error) {
+func (m *manager) GetOngoingSwaps() ([]*Info, error) {
 	m.RLock()
 	defer m.RUnlock()
-	swaps := make([]Info, len(m.ongoing))
+	swaps := make([]*Info, len(m.ongoing))
 	i := 0
 	for _, s := range m.ongoing {
-		swaps[i] = *s
+		sCopy := new(Info)
+		*sCopy = *s
+		swaps[i] = sCopy
 		i++
 	}
 	return swaps, nil

--- a/protocol/xmrmaker/backend_offers.go
+++ b/protocol/xmrmaker/backend_offers.go
@@ -13,9 +13,6 @@ func (b *Instance) MakeOffer(
 	relayerEndpoint string,
 	relayerCommissionRate *apd.Decimal,
 ) (*types.OfferExtra, error) {
-	b.backend.XMRClient().Lock()
-	defer b.backend.XMRClient().Unlock()
-
 	// get monero balance
 	balance, err := b.backend.XMRClient().GetBalance(0)
 	if err != nil {

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -235,9 +235,6 @@ func (inst *Instance) GetMoneroBalance() (string, *wallet.GetBalanceResponse, er
 	if err != nil {
 		return "", nil, err
 	}
-	if err = inst.backend.XMRClient().Refresh(); err != nil {
-		return "", nil, err
-	}
 	balance, err := inst.backend.XMRClient().GetBalance(0)
 	if err != nil {
 		return "", nil, err

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -137,7 +137,7 @@ func (inst *Instance) recoverRefund(s *swap.Info, abWalletKey *mcrypto.PrivateKe
 	}
 	defer abCli.CloseAndRemoveWallet()
 
-	transfers, err := abCli.SweepAll(inst.backend.Ctx(), refundDest, 0, monero.MinSpendConfirmations)
+	transfers, err := abCli.SweepAll(inst.backend.Ctx(), refundDest, 0, monero.SweepToSelfConfirmations)
 	if err != nil {
 		return err
 	}

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -129,7 +129,7 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 func (inst *Instance) recoverRefund(s *swap.Info, abWalletKey *mcrypto.PrivateKeyPair) error {
 	primaryCli := inst.backend.XMRClient()
 	refundDest := primaryCli.PrimaryAddress()
-	conf := primaryCli.CreateABWalletConf("xmrmaker-swap-wallet-refund")
+	conf := primaryCli.CreateWalletConf("xmrmaker-swap-wallet-refund")
 	log.Infof("Refunding XMR from swap ID %s to wallet address %s", s.ID, abWalletKey.Address(inst.backend.Env()))
 	abCli, err := monero.CreateSpendWalletFromKeys(conf, abWalletKey, s.MoneroStartHeight)
 	if err != nil {

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -128,7 +128,7 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 
 func (inst *Instance) recoverRefund(s *swap.Info, abWalletKey *mcrypto.PrivateKeyPair) error {
 	primaryCli := inst.backend.XMRClient()
-	conf := primaryCli.CreateABWalletConf()
+	conf := primaryCli.CreateABWalletConf("xmrmaker-swap-wallet-refund")
 	log.Infof("refunded XMR from swap %s: wallet addr is %s", s.ID, abWalletKey.Address(inst.backend.Env()))
 	abCli, err := monero.CreateSpendWalletFromKeys(conf, abWalletKey, s.MoneroStartHeight)
 	if err != nil {

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -188,7 +188,7 @@ func TestInstance_createOngoingSwap(t *testing.T) {
 	)
 	offerDB.EXPECT().GetOffer(s.ID).Return(offer, nil)
 
-	err = inst.createOngoingSwap(*s)
+	err = inst.createOngoingSwap(s)
 	require.NoError(t, err)
 
 	inst.swapMu.Lock()

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -137,8 +137,6 @@ func newTestInstanceAndDBAndNet(t *testing.T) (*Instance, *offers.MockDatabase, 
 
 	oneXMR := coins.MoneroToPiconero(apd.New(1, 0))
 	monero.MineMinXMRBalance(t, b.XMRClient(), oneXMR)
-	err = b.XMRClient().Refresh()
-	require.NoError(t, err)
 	return xmrmaker, db, net
 }
 

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -425,7 +425,7 @@ func (s *swapState) reclaimMonero(skA *mcrypto.PrivateSpendKey) (mcrypto.Address
 		return "", err
 	}
 
-	conf := s.XMRClient().CreateABWalletConf("xmrmaker-swap-wallet-refund")
+	conf := s.XMRClient().CreateWalletConf("xmrmaker-swap-wallet-refund")
 	abWalletCli, err := monero.CreateSpendWalletFromKeys(conf, kpAB, s.moneroStartHeight)
 	if err != nil {
 		return "", err

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -432,7 +432,12 @@ func (s *swapState) reclaimMonero(skA *mcrypto.PrivateSpendKey) (mcrypto.Address
 	}
 	defer abWalletCli.CloseAndRemoveWallet()
 
-	transfers, err := abWalletCli.SweepAll(s.ctx, s.XMRClient().PrimaryAddress(), 0, 2)
+	transfers, err := abWalletCli.SweepAll(
+		s.ctx,
+		s.XMRClient().PrimaryAddress(),
+		0,
+		monero.SweepToSelfConfirmations,
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to sweep refund back to primary wallet: %w", err)
 	}

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -108,7 +108,7 @@ func newSwapStateFromStart(
 		}
 	}
 
-	moneroStartHeight, err := b.XMRClient().GetChainHeight()
+	moneroStartHeight, err := b.XMRClient().GetHeight()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -433,7 +433,7 @@ func sweepRefundBack(
 			return err
 		}
 	}
-	log.Infof("Sweeping refund of %s XMR (minus %s XMR TX fees) back to primary address %s",
+	log.Infof("Sweeping refund of %s XMR back to primary address %s",
 		coins.FmtPiconeroAmtAsXMR(balance.Balance), primaryCli.PrimaryAddress())
 	sweepResp, err := abWalletCli.SweepAll(primaryCli.PrimaryAddress(), 0)
 	if err != nil {

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -418,7 +418,7 @@ func sweepRefundBack(
 	abPrivKeyPair *mcrypto.PrivateKeyPair,
 	restoreHeight uint64,
 ) error {
-	conf := primaryCli.CreateABWalletConf()
+	conf := primaryCli.CreateABWalletConf("xmrmaker-swap-wallet-refund")
 	abWalletCli, err := monero.CreateSpendWalletFromKeys(conf, abPrivKeyPair, restoreHeight)
 	if err != nil {
 		return err

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -38,7 +38,7 @@ func newTestSwapStateAndDB(t *testing.T) (*Instance, *swapState, *offers.MockDat
 		types.NewOffer("", new(apd.Decimal), new(apd.Decimal), new(coins.ExchangeRate), types.EthAssetETH),
 		&types.OfferExtra{},
 		xmrmaker.offerManager,
-		coins.NewPiconeroAmount(33),
+		coins.MoneroToPiconero(coins.StrToDecimal("0.05")),
 		desiredAmount,
 	)
 	require.NoError(t, err)

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -313,6 +313,8 @@ func TestSwapState_Exit_Reclaim(t *testing.T) {
 
 	balAfterLock, err := s.XMRClient().GetBalance(0)
 	require.NoError(t, err)
+	t.Logf("Balance after locking funds: %s XMR (%d blocks to unlock)",
+		coins.FmtPiconeroAmtAsXMR(balAfterLock.Balance), balAfterLock.BlocksToUnlock)
 
 	// call refund w/ XMRTaker's secret
 	secret := xmrtakerKeysAndProof.DLEqProof.Secret()
@@ -341,6 +343,8 @@ func TestSwapState_Exit_Reclaim(t *testing.T) {
 
 	balance, err := s.XMRClient().GetBalance(0)
 	require.NoError(t, err)
+	t.Logf("End balance after refund: %s XMR (%d blocks to unlock)",
+		coins.FmtPiconeroAmtAsXMR(balance.Balance), balance.BlocksToUnlock)
 	require.Greater(t, balance.Balance, balAfterLock.Balance) // increased by refund (minus some fees)
 	require.Equal(t, types.CompletedRefund, s.info.Status)
 }

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -311,6 +311,9 @@ func TestSwapState_Exit_Reclaim(t *testing.T) {
 	_, err = s.lockFunds(coins.MoneroToPiconero(s.info.ProvidedAmount))
 	require.NoError(t, err)
 
+	balAfterLock, err := s.XMRClient().GetBalance(0)
+	require.NoError(t, err)
+
 	// call refund w/ XMRTaker's secret
 	secret := xmrtakerKeysAndProof.DLEqProof.Secret()
 	var sc [32]byte
@@ -338,9 +341,7 @@ func TestSwapState_Exit_Reclaim(t *testing.T) {
 
 	balance, err := s.XMRClient().GetBalance(0)
 	require.NoError(t, err)
-	providedPiconeros, err := coins.MoneroToPiconero(s.info.ProvidedAmount).Uint64()
-	require.NoError(t, err)
-	require.Equal(t, providedPiconeros, balance.Balance)
+	require.Greater(t, balance.Balance, balAfterLock.Balance) // increased by refund (minus some fees)
 	require.Equal(t, types.CompletedRefund, s.info.Status)
 }
 

--- a/protocol/xmrmaker/utils.go
+++ b/protocol/xmrmaker/utils.go
@@ -1,7 +1,15 @@
 package xmrmaker
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/athanorlabs/atomic-swap/coins"
+	"github.com/athanorlabs/atomic-swap/common"
+	"github.com/athanorlabs/atomic-swap/common/types"
+	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
 	contracts "github.com/athanorlabs/atomic-swap/ethereum"
+	"github.com/athanorlabs/atomic-swap/monero"
 	"github.com/athanorlabs/atomic-swap/net/message"
 )
 
@@ -17,4 +25,32 @@ func convertContractSwap(msg *message.ContractSwap) contracts.SwapFactorySwap {
 		Value:        msg.Value,
 		Nonce:        msg.Nonce,
 	}
+}
+
+func sweepRefund(
+	ctx context.Context,
+	env common.Environment,
+	swapID types.Hash,
+	abWalletConf *monero.WalletClientConf,
+	walletRestoreHeight uint64,
+	abWalletKey *mcrypto.PrivateKeyPair,
+	refundDest mcrypto.Address,
+) error {
+	log.Infof("Refunding XMR from swap ID %s to address %s", swapID, abWalletKey.Address(env))
+	abCli, err := monero.CreateSpendWalletFromKeys(abWalletConf, abWalletKey, walletRestoreHeight)
+	if err != nil {
+		return err
+	}
+	defer abCli.CloseAndRemoveWallet()
+
+	transfers, err := abCli.SweepAll(ctx, refundDest, 0, monero.SweepToSelfConfirmations)
+	if err != nil {
+		return fmt.Errorf("swap ID %s failed to recover refund: %w", swapID, err)
+	}
+	for _, transfer := range transfers {
+		// It is unlikely that anyone will ever see more than one of these messages
+		log.Infof("Refunded %s XMR from swap to primary wallet (%s XMR lost to fees)",
+			coins.FmtPiconeroAmtAsXMR(transfer.Amount), coins.FmtPiconeroAmtAsXMR(transfer.Fee))
+	}
+	return nil
 }

--- a/protocol/xmrtaker/claim.go
+++ b/protocol/xmrtaker/claim.go
@@ -96,7 +96,7 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 		return "", err
 	}
 
-	conf := s.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-claim")
+	conf := s.XMRClient().CreateWalletConf("xmrtaker-swap-wallet-claim")
 	abWalletCli, err := monero.CreateSpendWalletFromKeys(conf, kpAB, s.walletScanHeight)
 	if err != nil {
 		return "", err

--- a/protocol/xmrtaker/claim.go
+++ b/protocol/xmrtaker/claim.go
@@ -95,7 +95,7 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 		return "", err
 	}
 
-	conf := s.XMRClient().CreateABWalletConf()
+	conf := s.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-claim")
 	abWalletCli, err := monero.CreateSpendWalletFromKeys(conf, kpAB, s.walletScanHeight)
 	if err != nil {
 		return "", err

--- a/protocol/xmrtaker/claim.go
+++ b/protocol/xmrtaker/claim.go
@@ -131,7 +131,7 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 		return "", fmt.Errorf("failed to wait for balance to unlock: %w", err)
 	}
 
-	transfers, err := s.XMRClient().SweepAll(s.ctx, depositAddr, 0, 2)
+	transfers, err := s.XMRClient().SweepAll(s.ctx, depositAddr, 0, monero.SweepToSelfConfirmations)
 	if err != nil {
 		return "", fmt.Errorf("failed to send funds to original account: %w", err)
 	}

--- a/protocol/xmrtaker/claim.go
+++ b/protocol/xmrtaker/claim.go
@@ -101,7 +101,6 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 	if err != nil {
 		return "", err
 	}
-	defer abWalletCli.CloseAndRemoveWallet()
 
 	if s.transferBack {
 		defer abWalletCli.CloseAndRemoveWallet()
@@ -122,8 +121,8 @@ func (s *swapState) claimMonero(skB *mcrypto.PrivateSpendKey) (mcrypto.Address, 
 
 	err = mcrypto.ValidateAddress(string(depositAddr), s.Env())
 	if err != nil {
-		log.Errorf("failed to transfer to original account, address %s is invalid", abAddr)
-		return abAddr, nil
+		log.Errorf("Failed to transfer XMR out of swap wallet, dest address %s is invalid: %s", abAddr, err)
+		return "", err
 	}
 
 	err = waitUntilBalanceUnlocks(s.ctx, abWalletCli)

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -20,8 +20,6 @@ import (
 func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr mcrypto.Address) {
 	// backend simulates the xmrmaker's instance
 	backend := newBackend(t)
-	err := backend.XMRClient().CreateWallet("test-wallet", "")
-	require.NoError(t, err)
 	monero.MineMinXMRBalance(t, backend.XMRClient(), coins.MoneroToPiconero(coins.StrToDecimal("1")))
 
 	// lock xmr

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -32,7 +32,6 @@ func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr mcrypto.Addr
 	transfer, err := backend.XMRClient().WaitForReceipt(&monero.WaitForReceiptRequest{
 		Ctx:              s.ctx,
 		TxID:             tResp.TxHash,
-		DestAddr:         xmrAddr,
 		NumConfirmations: monero.MinSpendConfirmations,
 		AccountIdx:       0,
 	})

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -22,21 +22,15 @@ func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr mcrypto.Addr
 	backend := newBackend(t)
 	monero.MineMinXMRBalance(t, backend.XMRClient(), coins.MoneroToPiconero(coins.StrToDecimal("1")))
 
-	// lock xmr
 	amt := s.expectedPiconeroAmount()
-	tResp, err := backend.XMRClient().Transfer(xmrAddr, 0, amt)
+	amtu64, err := amt.Uint64()
 	require.NoError(t, err)
-	t.Logf("transferred %d pico XMR (fees %d) to account %s", tResp.Amount, tResp.Fee, xmrAddr)
-	require.Equal(t, amt.CmpU64(tResp.Amount), 0)
-
-	transfer, err := backend.XMRClient().WaitForReceipt(&monero.WaitForReceiptRequest{
-		Ctx:              s.ctx,
-		TxID:             tResp.TxHash,
-		NumConfirmations: monero.MinSpendConfirmations,
-		AccountIdx:       0,
-	})
+	// lock xmr
+	transfer, err := backend.XMRClient().Transfer(s.ctx, xmrAddr, 0, amt, monero.MinSpendConfirmations)
 	require.NoError(t, err)
-	t.Logf("Transfer mined at block=%d with %d confirmations", transfer.Height, transfer.Confirmations)
+	require.Equal(t, transfer.Amount, amtu64)
+	t.Logf("Transferred %d pico XMR (fees %d) to account %s", transfer.Amount, transfer.Fee, xmrAddr)
+	t.Logf("Transfer was mined at block=%d with %d confirmations", transfer.Height, transfer.Confirmations)
 
 	// send notification that monero was locked
 	lmsg := &message.NotifyXMRLock{

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -100,7 +100,7 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 			return err
 		}
 
-		conf := inst.backend.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-db-restored")
+		conf := inst.backend.XMRClient().CreateWalletConf("xmrtaker-swap-wallet-db-restored")
 		abWalletCli, err := monero.CreateSpendWalletFromKeys(
 			conf,
 			kp, // TODO: Fix the key here?

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -100,8 +100,7 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 			return err
 		}
 
-		// TODO: do we want to transfer this back to the original account?
-		conf := inst.backend.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet")
+		conf := inst.backend.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-db-restored")
 		abWalletCli, err := monero.CreateSpendWalletFromKeys(
 			conf,
 			kp, // TODO: Fix the key here?

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -101,7 +101,7 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 		}
 
 		// TODO: do we want to transfer this back to the original account?
-		conf := inst.backend.XMRClient().CreateABWalletConf()
+		conf := inst.backend.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet")
 		abWalletCli, err := monero.CreateSpendWalletFromKeys(
 			conf,
 			kp, // TODO: Fix the key here?

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -111,7 +111,20 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 		}
 		if inst.transferBack {
 			defer abWalletCli.CloseAndRemoveWallet()
-			// TODO: Do transfer here after key issue are fixed
+			// TODO: Get unit test coverage on these lines when we think the key issues are fixed.
+			transfers, err := abWalletCli.SweepAll(
+				inst.backend.Ctx(),
+				inst.backend.XMRClient().PrimaryAddress(),
+				0,
+				monero.SweepToSelfConfirmations,
+			)
+			if err != nil {
+				return err
+			}
+			for _, transfer := range transfers {
+				log.Infof("Swept %s XMR (%s XMR lost to fees) from restored swap ID %s to primary wallet",
+					coins.FmtPiconeroAmtAsXMR(transfer.Amount), coins.FmtPiconeroAmtAsXMR(transfer.Fee), s.ID)
+			}
 		} else {
 			defer abWalletCli.Close() // leave the wallet in place, as funds were not transferred back
 		}

--- a/protocol/xmrtaker/instance_test.go
+++ b/protocol/xmrtaker/instance_test.go
@@ -76,7 +76,7 @@ func TestInstance_createOngoingSwap(t *testing.T) {
 		makerKeys.SpendKey().Public(), makerKeys.ViewKey(), nil,
 	)
 
-	err = inst.createOngoingSwap(*s)
+	err = inst.createOngoingSwap(s)
 	require.NoError(t, err)
 
 	inst.swapMu.Lock()

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -212,10 +212,6 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 
 	log.Debugf("generated view-only wallet to check funds: %s", abViewCli.WalletName())
 
-	if err = abViewCli.Refresh(); err != nil {
-		return fmt.Errorf("failed to refresh client: %w", err)
-	}
-
 	balance, err := abViewCli.GetBalance(0)
 	if err != nil {
 		return fmt.Errorf("failed to get balance: %w", err)

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -203,7 +203,7 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 		return fmt.Errorf("address received in message does not match expected address")
 	}
 
-	conf := s.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-verify-funds")
+	conf := s.XMRClient().CreateWalletConf("xmrtaker-swap-wallet-verify-funds")
 	abViewCli, err := monero.CreateViewOnlyWalletFromKeys(conf, vk, lockedAddr, s.walletScanHeight)
 	if err != nil {
 		return fmt.Errorf("failed to generate view-only wallet to verify locked XMR: %w", err)

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -203,7 +203,7 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 		return fmt.Errorf("address received in message does not match expected address")
 	}
 
-	conf := s.XMRClient().CreateABWalletConf()
+	conf := s.XMRClient().CreateABWalletConf("xmrtaker-swap-wallet-verify-funds")
 	abViewCli, err := monero.CreateViewOnlyWalletFromKeys(conf, vk, lockedAddr, s.walletScanHeight)
 	if err != nil {
 		return fmt.Errorf("failed to generate view-only wallet to verify locked XMR: %w", err)

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
+	"github.com/athanorlabs/atomic-swap/monero"
 	"github.com/athanorlabs/atomic-swap/net/message"
 	pcommon "github.com/athanorlabs/atomic-swap/protocol"
 
@@ -202,25 +203,20 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 		return fmt.Errorf("address received in message does not match expected address")
 	}
 
-	s.XMRClient().Lock()
-	defer s.XMRClient().Unlock()
-
-	t := time.Now().Format(common.TimeFmtNSecs)
-	walletName := fmt.Sprintf("xmrtaker-viewonly-wallet-%s", t)
-	err := s.XMRClient().GenerateViewOnlyWalletFromKeys(
-		vk, lockedAddr, s.walletScanHeight, walletName, "",
-	)
+	conf := s.XMRClient().CreateABWalletConf()
+	abViewCli, err := monero.CreateViewOnlyWalletFromKeys(conf, vk, lockedAddr, s.walletScanHeight)
 	if err != nil {
 		return fmt.Errorf("failed to generate view-only wallet to verify locked XMR: %w", err)
 	}
+	defer abViewCli.CloseAndRemoveWallet()
 
-	log.Debugf("generated view-only wallet to check funds: %s", walletName)
+	log.Debugf("generated view-only wallet to check funds: %s", abViewCli.WalletName())
 
-	if err = s.XMRClient().Refresh(); err != nil {
+	if err = abViewCli.Refresh(); err != nil {
 		return fmt.Errorf("failed to refresh client: %w", err)
 	}
 
-	balance, err := s.XMRClient().GetBalance(0)
+	balance, err := abViewCli.GetBalance(0)
 	if err != nil {
 		return fmt.Errorf("failed to get balance: %w", err)
 	}
@@ -230,8 +226,7 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 
 	if s.expectedPiconeroAmount().CmpU64(balance.Balance) > 0 {
 		return fmt.Errorf("locked XMR amount is less than expected: got %s, expected %s",
-			coins.NewPiconeroAmount(balance.Balance).AsMonero().Text('f'),
-			s.ExpectedAmount().Text('f'))
+			coins.FmtPiconeroAmtAsXMR(balance.Balance), s.ExpectedAmount().Text('f'))
 	}
 
 	// Monero received from a transfer is locked for a minimum of 10 confirmations before
@@ -244,10 +239,6 @@ func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
 	if balance.BlocksToUnlock > 1 {
 		return fmt.Errorf("received XMR funds are not unlocked as required (blocks-to-unlock=%d)",
 			balance.BlocksToUnlock)
-	}
-
-	if err = s.XMRClient().CloseWallet(); err != nil {
-		return fmt.Errorf("failed to close wallet: %w", err)
 	}
 
 	close(s.xmrLockedCh)

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -105,7 +105,7 @@ func newSwapStateFromStart(
 	stage := types.ExpectingKeys
 	statusCh := make(chan types.Status, 16)
 
-	moneroStartNumber, err := b.XMRClient().GetChainHeight()
+	moneroStartNumber, err := b.XMRClient().GetHeight()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -240,14 +240,7 @@ func lockXMRFunds(
 	amount *coins.PiconeroAmount,
 ) string {
 	monero.MineMinXMRBalance(t, wc, amount)
-	transResp, err := wc.Transfer(destAddr, 0, amount)
-	require.NoError(t, err)
-	transfer, err := wc.WaitForReceipt(&monero.WaitForReceiptRequest{
-		Ctx:              ctx,
-		TxID:             transResp.TxHash,
-		NumConfirmations: monero.MinSpendConfirmations,
-		AccountIdx:       0,
-	})
+	transfer, err := wc.Transfer(ctx, destAddr, 0, amount, monero.MinSpendConfirmations)
 	require.NoError(t, err)
 	return transfer.TxID
 }

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -245,7 +245,6 @@ func lockXMRFunds(
 	transfer, err := wc.WaitForReceipt(&monero.WaitForReceiptRequest{
 		Ctx:              ctx,
 		TxID:             transResp.TxHash,
-		DestAddr:         destAddr,
 		NumConfirmations: monero.MinSpendConfirmations,
 		AccountIdx:       0,
 	})

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -76,7 +76,7 @@ func (*mockSwapManager) GetPastSwap(id types.Hash) (*swap.Info, error) {
 	return &swap.Info{}, nil
 }
 
-func (*mockSwapManager) GetOngoingSwaps() ([]swap.Info, error) {
+func (*mockSwapManager) GetOngoingSwaps() ([]*swap.Info, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR creates a new `monero-wallet-rpc` instance for temporary swap wallets. This eliminates the need for monero wallet locking, as `monero-wallet-rpc` instances now never switch between wallets. They just use one wallet from the time they are created until they are closed. Simultaneous transactions from the same primary wallet for different swaps is safe. We only required the locking to prevent wallet switching.