### PR TITLE
rounding fixes

### DIFF
--- a/cmd/relayer/validate.go
+++ b/cmd/relayer/validate.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/athanorlabs/atomic-swap/coins"
-	contracts "github.com/athanorlabs/atomic-swap/ethereum"
 	rcommon "github.com/athanorlabs/go-relayer/common"
-
 	"github.com/cockroachdb/apd/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+
+	"github.com/athanorlabs/atomic-swap/coins"
+	contracts "github.com/athanorlabs/atomic-swap/ethereum"
 )
 
 var (

--- a/cmd/relayer/validate_test.go
+++ b/cmd/relayer/validate_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	contracts "github.com/athanorlabs/atomic-swap/ethereum"
 	"github.com/cockroachdb/apd/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
+
+	contracts "github.com/athanorlabs/atomic-swap/ethereum"
 )
 
 func TestValidateRelayerFee(t *testing.T) {

--- a/coins/coins.go
+++ b/coins/coins.go
@@ -178,7 +178,7 @@ func (a *WeiAmount) BigInt() *big.Int {
 	if err != nil {
 		panic(err)
 	}
-	if cond.Rounded() {
+	if cond.Inexact() {
 		// We round when converting from Ether to Wei, so we shouldn't see this
 		log.Warn("Converting WeiAmount=%s to big.Int required rounding", a)
 	}
@@ -252,7 +252,7 @@ func (a *ERC20TokenAmount) BigInt() *big.Int {
 	if err != nil {
 		panic(err)
 	}
-	if cond.Rounded() {
+	if cond.Inexact() {
 		log.Warn("Converting ERC20TokenAmount=%s (digits=%d) to big.Int required rounding", a.amount, a.numDecimals)
 	}
 	return new(big.Int).SetBytes(wholeTokenUnits.Coeff.Bytes())

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -2,6 +2,7 @@ package pricefeed
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -16,12 +17,22 @@ func init() {
 	logging.SetLogLevel("pricefeed", "debug")
 }
 
+func getMainnetEndpoint() string {
+	endpoint := os.Getenv("ETH_MAINNET_ENDPOINT")
+	if endpoint == "" {
+		endpoint = mainnetEndpoint
+	}
+	return endpoint
+}
+
 func TestGetETHUSDPrice_mainnet(t *testing.T) {
-	ec, err := ethclient.Dial(mainnetEndpoint)
+	ec, err := ethclient.Dial(getMainnetEndpoint())
 	require.NoError(t, err)
+	defer ec.Close()
 
 	feed, err := GetETHUSDPrice(context.Background(), ec)
 	require.NoError(t, err)
+	t.Logf("%s is $%s (updated: %s)", feed.Description, feed.Price, feed.UpdatedAt)
 	assert.Equal(t, "ETH / USD", feed.Description)
 	assert.False(t, feed.Price.Negative)
 	assert.False(t, feed.Price.IsZero())
@@ -36,11 +47,13 @@ func TestGetETHUSDPrice_dev(t *testing.T) {
 }
 
 func TestGetXMRUSDPrice_mainnet(t *testing.T) {
-	ec, err := ethclient.Dial(mainnetEndpoint)
+	ec, err := ethclient.Dial(getMainnetEndpoint())
 	require.NoError(t, err)
+	defer ec.Close()
 
 	feed, err := GetXMRUSDPrice(context.Background(), ec)
 	require.NoError(t, err)
+	t.Logf("%s is $%s (updated: %s)", feed.Description, feed.Price, feed.UpdatedAt)
 	assert.Equal(t, "XMR / USD", feed.Description)
 	assert.False(t, feed.Price.Negative)
 	assert.False(t, feed.Price.IsZero())

--- a/protocol/xmrmaker/claim.go
+++ b/protocol/xmrmaker/claim.go
@@ -181,9 +181,13 @@ func calculateRelayerCommission(swapWeiAmt *big.Int, commissionRate *apd.Decimal
 		return nil, errRelayerCommissionRateTooHigh
 	}
 
+	decimalCtx := coins.DecimalCtx()
 	feeValue := new(apd.Decimal)
-	_, err := coins.DecimalCtx().Mul(feeValue, coins.NewWeiAmount(swapWeiAmt).Decimal(), commissionRate)
+	_, err := decimalCtx.Mul(feeValue, coins.NewWeiAmount(swapWeiAmt).Decimal(), commissionRate)
 	if err != nil {
+		return nil, err
+	}
+	if _, err = decimalCtx.RoundToIntegralValue(feeValue, feeValue); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
* When checking conditions after an APD (arbitrary precision decimal) math operation, `Rounded` is set even when zeros are chopped from a coefficient. Our checks needed to check for `Inexact` instead.
* `calculateRelayerCommission` now rounds the returned relayer commission to the nearest whole Wei value.
* Updated our pricefeed tests to read environment variable for the ETH mainnet endpoint if set