### PR TITLE
cache monero download

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -42,9 +42,9 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Cache monero download
+        id: monero-download
         uses: actions/cache@v3
         with:
-          id: monero-download
           path: ./monero-bin/
           key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -41,17 +41,17 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-mod
 
-      - name: Cache monero download
-        id: monero-download
+      - name: Cache monero install
+        id: monero-install
         uses: actions/cache@v3
         with:
           path: |
             ./monero-bin
             ./monero-x86_64-linux-gnu-*
-          key: monero-download
+          key: monero-install
 
       - name: Install monero
-        if: steps.monero-download.outputs.cache-hit != 'true'
+        if: steps.monero-install.outputs.cache-hit != 'true'
         run: ./scripts/install-monero-linux.sh
 
       - name: Run build

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./monero-bin/
-          key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
+          key: monero-download
 
       - name: Install monero
         if: steps.monero-download.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -41,6 +41,17 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-mod
 
+      - name: Cache monero download
+        uses: actions/cache@v3
+        with:
+          id: monero-download
+          path: ./monero-bin/
+          key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
+
+      - name: Install monero
+        if: steps.monero-download.outputs.cache-hit != 'true'
+        run: ./scripts/install-monero-linux.sh
+
       - name: Run build
         run: make build
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -45,7 +45,9 @@ jobs:
         id: monero-download
         uses: actions/cache@v3
         with:
-          path: ./monero-bin/
+          path: |
+            ./monero-bin
+            ./monero-x86_64-linux-gnu-*
           key: monero-download
 
       - name: Install monero

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,6 +57,8 @@ jobs:
         run: make build
         
       - name: Run unit tests
+        env:
+          ETH_MAINNET_ENDPOINT: ${{ secrets.ETH_MAINNET_ENDPOINT }}
         run: ./scripts/run-unit-tests.sh
 
       - name: Run coverage

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,9 @@ jobs:
         id: monero-download
         uses: actions/cache@v3
         with:
-          path: ./monero-bin/
+          path: |
+            ./monero-bin
+            ./monero-x86_64-linux-gnu-*
           key: monero-download
 
       - name: Install monero

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,9 +41,9 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Cache monero download
+        id: monero-download
         uses: actions/cache@v3
         with:
-          id: monero-download
           path: ./monero-bin/
           key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,17 +40,17 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-mod
 
-      - name: Cache monero download
-        id: monero-download
+      - name: Cache monero install
+        id: monero-install
         uses: actions/cache@v3
         with:
           path: |
             ./monero-bin
             ./monero-x86_64-linux-gnu-*
-          key: monero-download
+          key: monero-install
 
       - name: Install monero
-        if: steps.monero-download.outputs.cache-hit != 'true'
+        if: steps.monero-install.outputs.cache-hit != 'true'
         run: ./scripts/install-monero-linux.sh
 
       - name: Run build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./monero-bin/
-          key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
+          key: monero-download
 
       - name: Install monero
         if: steps.monero-download.outputs.cache-hit != 'true'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,6 +40,17 @@ jobs:
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-mod
 
+      - name: Cache monero download
+        uses: actions/cache@v3
+        with:
+          id: monero-download
+          path: ./monero-bin/
+          key: monero-download-${{ hashFiles('monero-bin/monerod', 'monero-bin/monero-wallet-rpc') }}
+
+      - name: Install monero
+        if: steps.monero-download.outputs.cache-hit != 'true'
+        run: ./scripts/install-monero-linux.sh
+
       - name: Run build
         run: make build
         

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ lint: lint-go lint-shell lint-solidity
 
 .PHONY: format-go
 format-go:
-	go fmt ./...
+	test -x $(GOPATH)/bin/goimports || go install golang.org/x/tools/cmd/goimports@latest
+	$(GOPATH)/bin/goimports -local github.com/athanorlabs/atomic-swap -w .
 
 .PHONY: format-shell
 format-shell:
@@ -73,9 +74,9 @@ bindings:
 .PHONY: mock
 mock:
 	go generate -run mockgen ./...
+	$(MAKE) format-go
 
 # Deletes all executables matching the directory names in cmd/
 .PHONY: clean
 clean:
 	rm -r bin/
-	

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -2,6 +2,7 @@ package pricefeed
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"testing"
 
@@ -17,16 +18,21 @@ func init() {
 	logging.SetLogLevel("pricefeed", "debug")
 }
 
-func getMainnetEndpoint() string {
+func getMainnetEndpoint(t *testing.T) string {
 	endpoint := os.Getenv("ETH_MAINNET_ENDPOINT")
 	if endpoint == "" {
 		endpoint = mainnetEndpoint
 	}
+	eURL, err := url.Parse(endpoint)
+	require.NoError(t, err)
+	// path and fragments may have API keys, so don't log them
+	t.Logf("mainnet endpoint is %s://%s", eURL.Scheme, eURL.Host)
+
 	return endpoint
 }
 
 func TestGetETHUSDPrice_mainnet(t *testing.T) {
-	ec, err := ethclient.Dial(getMainnetEndpoint())
+	ec, err := ethclient.Dial(getMainnetEndpoint(t))
 	require.NoError(t, err)
 	defer ec.Close()
 
@@ -47,7 +53,7 @@ func TestGetETHUSDPrice_dev(t *testing.T) {
 }
 
 func TestGetXMRUSDPrice_mainnet(t *testing.T) {
-	ec, err := ethclient.Dial(getMainnetEndpoint())
+	ec, err := ethclient.Dial(getMainnetEndpoint(t))
 	require.NoError(t, err)
 	defer ec.Close()
 

--- a/protocol/backend/mock_recovery_db.go
+++ b/protocol/backend/mock_recovery_db.go
@@ -7,11 +7,12 @@ package backend
 import (
 	reflect "reflect"
 
+	common "github.com/ethereum/go-ethereum/common"
+	gomock "github.com/golang/mock/gomock"
+
 	types "github.com/athanorlabs/atomic-swap/common/types"
 	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
 	db "github.com/athanorlabs/atomic-swap/db"
-	common "github.com/ethereum/go-ethereum/common"
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockRecoveryDB is a mock of RecoveryDB interface.

--- a/protocol/xmrmaker/offers/mocks.go
+++ b/protocol/xmrmaker/offers/mocks.go
@@ -7,9 +7,10 @@ package offers
 import (
 	reflect "reflect"
 
-	types "github.com/athanorlabs/atomic-swap/common/types"
 	common "github.com/ethereum/go-ethereum/common"
 	gomock "github.com/golang/mock/gomock"
+
+	types "github.com/athanorlabs/atomic-swap/common/types"
 )
 
 // MockDatabase is a mock of Database interface.


### PR DESCRIPTION
This PR should significantly decrease 2 common CI failures:
(1) Issues downloading the monero binaries (we now cache them). This also reduces build time and bandwidth costs for the monero community.
(2) We use a reliable mainnet endpoint from a github actions secret for unit tests that require it.

This PR also switches us from `go fmt` to `go imports` for formatting the code.