### PR TITLE
update relayer fee to be fixed at 0.009 ETH

### DIFF
--- a/cmd/relayer/main.go
+++ b/cmd/relayer/main.go
@@ -121,7 +121,7 @@ var (
 		&cli.StringFlag{
 			Name: flagRelayerFee,
 			Usage: "Minimum commission fee to receive in ETH:" +
-				" eg. --relayer-commission=0.01 for a fee of 0.01 ETH",
+				" eg. --relayer-fee=0.01 for a fee of 0.01 ETH",
 			Value: common.DefaultRelayerFee.Text('f'),
 		},
 	}
@@ -255,7 +255,7 @@ func run(c *cli.Context) error {
 	}
 
 	if relayerFee.Cmp(apd.New(1, -1)) > 0 {
-		return errors.New("relayer commission is too high: must be less than 0.1 ETH")
+		return errors.New("relayer fee is too high: must be less than 0.1 ETH")
 	}
 
 	feeWei := coins.EtherToWei(relayerFee).BigInt()

--- a/cmd/relayer/main.go
+++ b/cmd/relayer/main.go
@@ -50,7 +50,7 @@ const (
 	flagLibp2pKey   = "libp2p-key"
 	flagLibp2pPort  = "libp2p-port"
 	flagBootnodes   = "bootnodes"
-	flagRelayerFee  = "relayer-fee"
+	flagMinFee      = "min-fee"
 
 	defaultLibp2pPort = 10900
 )
@@ -119,9 +119,9 @@ var (
 			EnvVars: []string{"SWAPD_BOOTNODES"},
 		},
 		&cli.StringFlag{
-			Name: flagRelayerFee,
-			Usage: "Minimum commission fee to receive in ETH:" +
-				" eg. --relayer-fee=0.01 for a fee of 0.01 ETH",
+			Name: flagMinFee,
+			Usage: "Minimum fee to receive for relaying a transaction (in ETH):" +
+				" eg. --min-fee=0.01 rejects any transactions with fee <0.01 ETH",
 			Value: common.DefaultRelayerFee.Text('f'),
 		},
 	}
@@ -249,20 +249,20 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	relayerFee, err := cliutil.ReadUnsignedDecimalFlag(c, flagRelayerFee)
+	minFee, err := cliutil.ReadUnsignedDecimalFlag(c, flagMinFee)
 	if err != nil {
 		return err
 	}
 
-	if relayerFee.Cmp(apd.New(1, -1)) > 0 {
+	if minFee.Cmp(apd.New(1, -1)) > 0 {
 		return errors.New("relayer fee is too high: must be less than 0.1 ETH")
 	}
 
-	feeWei := coins.EtherToWei(relayerFee).BigInt()
+	feeWei := coins.EtherToWei(minFee).BigInt()
 	v := &validator{
 		ctx:              ctx,
 		ec:               ec,
-		relayerFee:       feeWei,
+		minFee:           feeWei,
 		forwarderAddress: forwarderAddr,
 	}
 

--- a/cmd/relayer/validate.go
+++ b/cmd/relayer/validate.go
@@ -79,7 +79,7 @@ func (v *validator) validateTransactionFunc(req *rcommon.SubmitTransactionReques
 	// 1. the `to` address is a swap contract;
 	// 2. the function being called is `claimRelayer`;
 	// 3. the fee passed to `claimRelayer` is equal to or greater
-	// than our desired commission percentage.
+	// than our desired fee.
 
 	forwarderAddr, err := contracts.CheckSwapFactoryContractCode(
 		v.ctx, v.ec, req.To,

--- a/cmd/relayer/validate.go
+++ b/cmd/relayer/validate.go
@@ -70,7 +70,7 @@ var (
 type validator struct {
 	ctx              context.Context
 	ec               *ethclient.Client
-	relayerFee       *big.Int
+	minFee           *big.Int
 	forwarderAddress ethcommon.Address
 }
 
@@ -106,7 +106,7 @@ func (v *validator) validateTransactionFunc(req *rcommon.SubmitTransactionReques
 		return err
 	}
 
-	err = validateRelayerFee(args, v.relayerFee)
+	err = validateFee(args, v.minFee)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func unpackData(data []byte) (map[string]interface{}, error) {
 	return args, nil
 }
 
-func validateRelayerFee(args map[string]interface{}, minFee *big.Int) error {
+func validateFee(args map[string]interface{}, minFee *big.Int) error {
 	fee, ok := args["fee"].(*big.Int)
 	if !ok {
 		// this shouldn't happen afaik

--- a/cmd/relayer/validate_test.go
+++ b/cmd/relayer/validate_test.go
@@ -85,7 +85,7 @@ func TestValidateRelayerFee(t *testing.T) {
 		require.Equal(t, unpacked["value"], tc.value)
 		require.Equal(t, unpacked["fee"], tc.fee)
 
-		err = validateRelayerFee(unpacked, tc.minFee)
+		err = validateFee(unpacked, tc.minFee)
 		if tc.expectErr {
 			require.Error(t, err)
 			continue

--- a/cmd/relayer/validate_test.go
+++ b/cmd/relayer/validate_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/apd/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -18,48 +17,47 @@ func TestValidateRelayerFee(t *testing.T) {
 	require.NoError(t, err)
 
 	type testCase struct {
-		value, fee       *big.Int
-		minFeePercentage *apd.Decimal
-		expectErr        bool
+		value, fee, minFee *big.Int
+		expectErr          bool
 	}
 
 	testCases := []testCase{
 		{
-			value:            big.NewInt(100),
-			fee:              big.NewInt(1),
-			minFeePercentage: apd.New(1, -2),
+			value:  big.NewInt(100),
+			fee:    big.NewInt(1),
+			minFee: big.NewInt(1),
 		},
 		{
-			value:            big.NewInt(100),
-			fee:              big.NewInt(2),
-			minFeePercentage: apd.New(1, -2),
+			value:  big.NewInt(100),
+			fee:    big.NewInt(2),
+			minFee: big.NewInt(1),
 		},
 		{
-			value:            big.NewInt(1000),
-			fee:              big.NewInt(1),
-			minFeePercentage: apd.New(1, -2),
-			expectErr:        true,
+			value:     big.NewInt(1000),
+			fee:       big.NewInt(1),
+			minFee:    big.NewInt(2),
+			expectErr: true,
 		},
 		{
-			value:            big.NewInt(100),
-			fee:              big.NewInt(100),
-			minFeePercentage: apd.New(1, 0),
+			value:  big.NewInt(100),
+			fee:    big.NewInt(100),
+			minFee: big.NewInt(1),
 		},
 		{
-			value:            big.NewInt(100),
-			fee:              big.NewInt(10),
-			minFeePercentage: apd.New(1, -1),
+			value:  big.NewInt(100),
+			fee:    big.NewInt(10),
+			minFee: big.NewInt(10),
 		},
 		{
-			value:            big.NewInt(10000),
-			fee:              big.NewInt(99),
-			minFeePercentage: apd.New(1, -2),
-			expectErr:        true,
+			value:     big.NewInt(10000),
+			fee:       big.NewInt(99),
+			minFee:    big.NewInt(100),
+			expectErr: true,
 		},
 		{
-			value:            big.NewInt(10000),
-			fee:              big.NewInt(101),
-			minFeePercentage: apd.New(1, -2),
+			value:  big.NewInt(10000),
+			fee:    big.NewInt(101),
+			minFee: big.NewInt(1),
 		},
 	}
 
@@ -87,7 +85,7 @@ func TestValidateRelayerFee(t *testing.T) {
 		require.Equal(t, unpacked["value"], tc.value)
 		require.Equal(t, unpacked["fee"], tc.fee)
 
-		err = validateRelayerFee(unpacked, tc.minFeePercentage)
+		err = validateRelayerFee(unpacked, tc.minFee)
 		if tc.expectErr {
 			require.Error(t, err)
 			continue

--- a/cmd/swapcli/errors.go
+++ b/cmd/swapcli/errors.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 )
 
-//nolint:lll
 var (
-	errNoDuration                         = fmt.Errorf("must provide non-zero --duration")
-	errCannotHaveGreaterThan100Commission = fmt.Errorf("%s must be less than 1", flagRelayerCommission)
-	errMustSetRelayerEndpoint             = fmt.Errorf("%s must be set if %s is set", flagRelayerEndpoint, flagRelayerCommission)
+	errNoDuration                  = fmt.Errorf("must provide non-zero --duration")
+	errCannotHaveGreaterThan100Fee = fmt.Errorf("%s must be less than 1", flagRelayerFee)
+	errMustSetRelayerEndpoint      = fmt.Errorf("%s must be set if %s is set", flagRelayerEndpoint, flagRelayerFee)
 )
 
 func errInvalidFlagValue(flagName string, err error) error {

--- a/cmd/swapcli/errors.go
+++ b/cmd/swapcli/errors.go
@@ -5,9 +5,9 @@ import (
 )
 
 var (
-	errNoDuration                  = fmt.Errorf("must provide non-zero --duration")
-	errCannotHaveGreaterThan100Fee = fmt.Errorf("%s must be less than 1", flagRelayerFee)
-	errMustSetRelayerEndpoint      = fmt.Errorf("%s must be set if %s is set", flagRelayerEndpoint, flagRelayerFee)
+	errNoDuration             = fmt.Errorf("must provide non-zero --duration")
+	errRelayerFeeTooHigh      = fmt.Errorf("%s must be less than or equal to 1", flagRelayerFee)
+	errMustSetRelayerEndpoint = fmt.Errorf("%s must be set if %s is set", flagRelayerEndpoint, flagRelayerFee)
 )
 
 func errInvalidFlagValue(flagName string, err error) error {

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -559,7 +559,7 @@ func runMake(ctx *cli.Context) error {
 		return errMustSetRelayerEndpoint
 	}
 	if relayerFee.Cmp(apd.New(1, 0)) > 0 {
-		return errCannotHaveGreaterThan100Fee
+		return errRelayerFeeTooHigh
 	}
 
 	printOfferSummary := func(offerResp *rpctypes.MakeOfferResponse) {

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -25,19 +25,19 @@ import (
 const (
 	defaultDiscoverSearchTimeSecs = 12
 
-	flagSwapdPort         = "swapd-port"
-	flagMinAmount         = "min-amount"
-	flagMaxAmount         = "max-amount"
-	flagPeerID            = "peer-id"
-	flagOfferID           = "offer-id"
-	flagOfferIDs          = "offer-ids"
-	flagExchangeRate      = "exchange-rate"
-	flagProvides          = "provides"
-	flagProvidesAmount    = "provides-amount"
-	flagRelayerCommission = "relayer-commission"
-	flagRelayerEndpoint   = "relayer-endpoint"
-	flagSearchTime        = "search-time"
-	flagSubscribe         = "subscribe"
+	flagSwapdPort       = "swapd-port"
+	flagMinAmount       = "min-amount"
+	flagMaxAmount       = "max-amount"
+	flagPeerID          = "peer-id"
+	flagOfferID         = "offer-id"
+	flagOfferIDs        = "offer-ids"
+	flagExchangeRate    = "exchange-rate"
+	flagProvides        = "provides"
+	flagProvidesAmount  = "provides-amount"
+	flagRelayerFee      = "relayer-fee"
+	flagRelayerEndpoint = "relayer-endpoint"
+	flagSearchTime      = "search-time"
+	flagSubscribe       = "subscribe"
 )
 
 var (
@@ -163,9 +163,9 @@ var (
 						Usage: "HTTP RPC endpoint of relayer to use for claiming funds. No relayer is used if this is not set",
 					},
 					&cli.StringFlag{
-						Name: flagRelayerCommission,
-						Usage: "Commission to pay the relayer in percentage of the swap value:" +
-							" eg. --relayer-commission=0.01 for 1% commission",
+						Name: flagRelayerFee,
+						Usage: "Fee to pay the relayer in ETH:" +
+							" eg. --relayer-fee=0.009 to pay 0.0009 ETH",
 					},
 					swapdPortFlag,
 				},
@@ -504,16 +504,16 @@ func runMake(ctx *cli.Context) error {
 	c := newRRPClient(ctx)
 
 	relayerEndpoint := ctx.String(flagRelayerEndpoint)
-	relayerCommission := new(apd.Decimal)
+	relayerFee := new(apd.Decimal)
 	if relayerEndpoint != "" {
-		if relayerCommission, err = cliutil.ReadUnsignedDecimalFlag(ctx, flagRelayerCommission); err != nil {
+		if relayerFee, err = cliutil.ReadUnsignedDecimalFlag(ctx, flagRelayerFee); err != nil {
 			return err
 		}
-	} else if ctx.IsSet(flagRelayerCommission) {
+	} else if ctx.IsSet(flagRelayerFee) {
 		return errMustSetRelayerEndpoint
 	}
-	if relayerCommission.Cmp(apd.New(1, 0)) > 0 {
-		return errCannotHaveGreaterThan100Commission
+	if relayerFee.Cmp(apd.New(1, 0)) > 0 {
+		return errCannotHaveGreaterThan100Fee
 	}
 
 	printOfferSummary := func(offerResp *rpctypes.MakeOfferResponse) {
@@ -537,7 +537,7 @@ func runMake(ctx *cli.Context) error {
 			exchangeRate,
 			ethAsset,
 			relayerEndpoint,
-			relayerCommission,
+			relayerFee,
 		)
 		if err != nil {
 			return err
@@ -555,7 +555,7 @@ func runMake(ctx *cli.Context) error {
 		return nil
 	}
 
-	resp, err := c.MakeOffer(min, max, exchangeRate, ethAsset, relayerEndpoint, relayerCommission)
+	resp, err := c.MakeOffer(min, max, exchangeRate, ethAsset, relayerEndpoint, relayerFee)
 	if err != nil {
 		return err
 	}

--- a/common/consts.go
+++ b/common/consts.go
@@ -39,6 +39,6 @@ const (
 	HardhatChainID = 31337
 )
 
-// DefaultRelayerCommission is the default commission percentage for swap relayers.
-// It's set to 0.01 or 1%.
-var DefaultRelayerCommission = apd.New(1, -2)
+// DefaultRelayerFee is the default fee for swap relayers.
+// It's set to 0.009 ETH.
+var DefaultRelayerFee = apd.New(9, -3)

--- a/common/rpctypes/types.go
+++ b/common/rpctypes/types.go
@@ -77,12 +77,12 @@ type TakeOfferRequest struct {
 
 // MakeOfferRequest ...
 type MakeOfferRequest struct {
-	MinAmount         *apd.Decimal        `json:"minAmount"`
-	MaxAmount         *apd.Decimal        `json:"maxAmount"`
-	ExchangeRate      *coins.ExchangeRate `json:"exchangeRate"`
-	EthAsset          string              `json:"ethAsset,omitempty"`
-	RelayerEndpoint   string              `json:"relayerEndpoint,omitempty"`
-	RelayerCommission *apd.Decimal        `json:"relayerCommission,omitempty"`
+	MinAmount       *apd.Decimal        `json:"minAmount"`
+	MaxAmount       *apd.Decimal        `json:"maxAmount"`
+	ExchangeRate    *coins.ExchangeRate `json:"exchangeRate"`
+	EthAsset        string              `json:"ethAsset,omitempty"`
+	RelayerEndpoint string              `json:"relayerEndpoint,omitempty"`
+	RelayerFee      *apd.Decimal        `json:"relayerFee,omitempty"`
 }
 
 // MakeOfferResponse ...

--- a/common/types/offer.go
+++ b/common/types/offer.go
@@ -146,9 +146,9 @@ func (o *Offer) validate() error {
 
 // OfferExtra represents extra data that is passed when an offer is made.
 type OfferExtra struct {
-	StatusCh          chan Status  `json:"-"`
-	RelayerEndpoint   string       `json:"relayerEndpoint"`
-	RelayerCommission *apd.Decimal `json:"relayerCommission"`
+	StatusCh        chan Status  `json:"-"`
+	RelayerEndpoint string       `json:"relayerEndpoint"`
+	RelayerFee      *apd.Decimal `json:"RelayerFee"`
 }
 
 // UnmarshalOffer deserializes a JSON offer, checking the version for compatibility before

--- a/common/types/offer.go
+++ b/common/types/offer.go
@@ -148,7 +148,7 @@ func (o *Offer) validate() error {
 type OfferExtra struct {
 	StatusCh        chan Status  `json:"-"`
 	RelayerEndpoint string       `json:"relayerEndpoint"`
-	RelayerFee      *apd.Decimal `json:"RelayerFee"`
+	RelayerFee      *apd.Decimal `json:"relayerFee"`
 }
 
 // UnmarshalOffer deserializes a JSON offer, checking the version for compatibility before

--- a/db/recovery_db_test.go
+++ b/db/recovery_db_test.go
@@ -81,10 +81,10 @@ func TestRecoveryDB_SwapRelayerInfo(t *testing.T) {
 	rdb := newTestRecoveryDB(t)
 	offerID := types.Hash{5, 6, 7, 8}
 
-	commission := coins.StrToDecimal("0.0135")
+	fee := coins.StrToDecimal("0.0135")
 	info := &types.OfferExtra{
-		RelayerEndpoint:   "endpoint",
-		RelayerCommission: commission,
+		RelayerEndpoint: "endpoint",
+		RelayerFee:      fee,
 	}
 
 	err := rdb.PutSwapRelayerInfo(offerID, info)
@@ -166,8 +166,8 @@ func TestRecoveryDB_DeleteSwap(t *testing.T) {
 	}
 
 	info := &types.OfferExtra{
-		RelayerEndpoint:   "endpoint",
-		RelayerCommission: coins.StrToDecimal("0.0135"),
+		RelayerEndpoint: "endpoint",
+		RelayerFee:      coins.StrToDecimal("0.0135"),
 	}
 
 	err = rdb.PutContractSwapInfo(offerID, si)

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -181,7 +181,7 @@ Parameters:
   zero address for regular ETH. default: regular ETH
 - `relayerEndpoint`: (optional) RPC endpoint of the relayer to use for submitting claim
   transactions.
-- `relayerCommission`: (optional) Commission in percentage that the relayer receives for
+- `relayerFee`: (optional) Fee in ETH that the relayer receives for
   submitting the claim transaction.
 
 Returns:

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -183,7 +183,7 @@ Parameters:
 - `relayerEndpoint`: (optional) RPC endpoint of the relayer to use for submitting claim
   transactions.
 - `relayerFee`: (optional) Fee in ETH that the relayer receives for
-  submitting the claim transaction.
+  submitting the claim transaction. If `relayerEndpoint` is set and this is not set, it defaults to 0.009 ETH.
 
 Returns:
 - `offerID`: ID of the swap offer.

--- a/protocol/xmrmaker/backend_offers.go
+++ b/protocol/xmrmaker/backend_offers.go
@@ -11,7 +11,7 @@ import (
 func (b *Instance) MakeOffer(
 	o *types.Offer,
 	relayerEndpoint string,
-	relayerCommissionRate *apd.Decimal,
+	relayerFee *apd.Decimal,
 ) (*types.OfferExtra, error) {
 	// get monero balance
 	balance, err := b.backend.XMRClient().GetBalance(0)
@@ -24,7 +24,7 @@ func (b *Instance) MakeOffer(
 		return nil, errUnlockedBalanceTooLow{unlockedBalance, o.MaxAmount}
 	}
 
-	extra, err := b.offerManager.AddOffer(o, relayerEndpoint, relayerCommissionRate)
+	extra, err := b.offerManager.AddOffer(o, relayerEndpoint, relayerFee)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrmaker/claim_test.go
+++ b/protocol/xmrmaker/claim_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cockroachdb/apd/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -19,6 +18,7 @@ import (
 	"github.com/athanorlabs/go-relayer/relayer"
 	rrpc "github.com/athanorlabs/go-relayer/rpc"
 
+	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	"github.com/athanorlabs/atomic-swap/dleq"
 	contracts "github.com/athanorlabs/atomic-swap/ethereum"
@@ -28,7 +28,6 @@ import (
 
 var (
 	defaultTestTimeoutDuration = big.NewInt(60 * 5)
-	relayerCommission, _, _    = apd.NewFromString("0.01")
 )
 
 // runRelayer starts the relayer and returns the endpoint URL
@@ -82,7 +81,7 @@ func runRelayer(
 }
 
 func TestSwapState_ClaimRelayer_ERC20(t *testing.T) {
-	initialBalance := big.NewInt(100000000000)
+	initialBalance := big.NewInt(90000000000000000)
 
 	sk := tests.GetMakerTestKey(t)
 	conn, chainID := tests.NewEthClient(t)
@@ -174,7 +173,7 @@ func testSwapStateClaimRelayer(t *testing.T, sk *ecdsa.PrivateKey, asset types.E
 		require.NoError(t, err)
 	}
 
-	value := big.NewInt(100000000000)
+	value := big.NewInt(90000000000000000)
 	nonce := big.NewInt(0)
 	txOpts.Value = value
 
@@ -229,7 +228,7 @@ func testSwapStateClaimRelayer(t *testing.T, sk *ecdsa.PrivateKey, asset types.E
 		contractAddr,
 		conn,
 		relayerEndpoint,
-		relayerCommission,
+		common.DefaultRelayerFee,
 		&swap,
 		id,
 		s,

--- a/protocol/xmrmaker/claim_test.go
+++ b/protocol/xmrmaker/claim_test.go
@@ -12,7 +12,6 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	rcommon "github.com/athanorlabs/go-relayer/common"
@@ -20,7 +19,6 @@ import (
 	"github.com/athanorlabs/go-relayer/relayer"
 	rrpc "github.com/athanorlabs/go-relayer/rpc"
 
-	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	"github.com/athanorlabs/atomic-swap/dleq"
 	contracts "github.com/athanorlabs/atomic-swap/ethereum"
@@ -252,37 +250,4 @@ func testSwapStateClaimRelayer(t *testing.T, sk *ecdsa.PrivateKey, asset types.E
 	stage, err := contract.Swaps(nil, id)
 	require.NoError(t, err)
 	require.Equal(t, contracts.StageCompleted, stage)
-}
-
-func TestCalculateRelayerCommissionValue(t *testing.T) {
-	swapValueEther := coins.StrToDecimal("4.567")
-	swapValueWei := coins.EtherToWei(swapValueEther).BigInt()
-	require.Equal(t, "4567000000000000000", swapValueWei.Text(10))
-
-	commissionRate := coins.StrToDecimal("0.01398")
-	const expectedCommissionETH = "0.06384666" // 4.567 * 0.01398
-
-	fee, err := calculateRelayerCommission(swapValueWei, commissionRate)
-	require.NoError(t, err)
-	require.Equal(t, expectedCommissionETH, coins.NewWeiAmount(fee).AsEther().Text('f'))
-}
-
-func TestCalculateRelayerCommissionValue_roundUp(t *testing.T) {
-	commissionRate := coins.StrToDecimal("0.10")
-	swapValueWei := big.NewInt(9999999995)     // 10% is 999999999.5
-	const expectedCommissionWei = "1000000000" // ceil(999999999.5)
-
-	fee, err := calculateRelayerCommission(swapValueWei, commissionRate)
-	require.NoError(t, err)
-	assert.Equal(t, expectedCommissionWei, fee.String())
-}
-
-func TestCalculateRelayerCommissionValue_roundDown(t *testing.T) {
-	commissionRate := coins.StrToDecimal("0.10")
-	swapValueWei := big.NewInt(9999999994)    // 10% is 999999999.4
-	const expectedCommissionWei = "999999999" // floor(999999999.4)
-
-	fee, err := calculateRelayerCommission(swapValueWei, commissionRate)
-	require.NoError(t, err)
-	assert.Equal(t, expectedCommissionWei, fee.String())
 }

--- a/protocol/xmrmaker/errors.go
+++ b/protocol/xmrmaker/errors.go
@@ -27,6 +27,7 @@ var (
 	errClaimedLogWrongEvent          = errors.New("log did not have the Claimed event as its first topic")
 	errClaimedLogWrongSwapID         = errors.New("log did not have the correct swap ID as its second topic")
 	errClaimedLogWrongSecret         = errors.New("log did not have the correct secret as its third topic")
+	errSwapValueTooLow               = errors.New("swap value is less than relayer fee")
 
 	// protocol initiation errors
 	errProtocolAlreadyInProgress = errors.New("protocol already in progress")

--- a/protocol/xmrmaker/errors.go
+++ b/protocol/xmrmaker/errors.go
@@ -19,7 +19,6 @@ var (
 	errSwapIDMismatch                = errors.New("hash of swap struct does not match swap ID")
 	errLockTxReverted                = errors.New("other party failed to lock ETH asset (transaction reverted)")
 	errInvalidETHLockedTransaction   = errors.New("eth locked tx was not to correct contract address")
-	errRelayerCommissionRateTooHigh  = errors.New("relayer commission must be less than 0.1 (10%)")
 	errInvalidT0                     = errors.New("invalid t0 value; asset was locked too far in the past")
 	errInvalidT1                     = errors.New("invalid swap timeout set by counterparty")
 	errRelayedTransactionTimeout     = errors.New("relayed transaction was not included within one minute")

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -154,7 +154,7 @@ func TestInstance_createOngoingSwap(t *testing.T) {
 	rdb := inst.backend.RecoveryDB().(*backend.MockRecoveryDB)
 
 	one := apd.New(1, 0)
-	rate := coins.ToExchangeRate(apd.New(1, 0)) // 100% relayer commission
+	rate := coins.ToExchangeRate(apd.New(1, 0))
 	offer := types.NewOffer(coins.ProvidesXMR, one, one, rate, types.EthAssetETH)
 
 	s := &pswap.Info{

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -82,7 +82,7 @@ func (m *Manager) GetOffer(id types.Hash) (*types.Offer, *types.OfferExtra, erro
 func (m *Manager) AddOffer(
 	offer *types.Offer,
 	relayerEndpoint string,
-	relayerCommission *apd.Decimal,
+	relayerFee *apd.Decimal,
 ) (*types.OfferExtra, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -99,9 +99,9 @@ func (m *Manager) AddOffer(
 	}
 
 	extra := &types.OfferExtra{
-		StatusCh:          make(chan types.Status, statusChSize),
-		RelayerEndpoint:   relayerEndpoint,
-		RelayerCommission: relayerCommission,
+		StatusCh:        make(chan types.Status, statusChSize),
+		RelayerEndpoint: relayerEndpoint,
+		RelayerFee:      relayerFee,
 	}
 
 	m.offers[id] = &offerWithExtra{

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -342,7 +342,7 @@ func (s *swapState) exit() error {
 
 		if s.info.Status != types.CompletedSuccess && s.offer.IsSet() {
 			// re-add offer, as it wasn't taken successfully
-			_, err = s.offerManager.AddOffer(s.offer, s.offerExtra.RelayerEndpoint, s.offerExtra.RelayerCommission)
+			_, err = s.offerManager.AddOffer(s.offer, s.offerExtra.RelayerEndpoint, s.offerExtra.RelayerFee)
 			if err != nil {
 				log.Warnf("failed to re-add offer %s: %s", s.offer.ID, err)
 			}

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -254,7 +254,7 @@ func (s *NetService) makeOffer(req *rpctypes.MakeOfferRequest) (*rpctypes.MakeOf
 		ethAsset,
 	)
 
-	offerExtra, err := s.xmrmaker.MakeOffer(offer, req.RelayerEndpoint, req.RelayerCommission)
+	offerExtra, err := s.xmrmaker.MakeOffer(offer, req.RelayerEndpoint, req.RelayerFee)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -181,7 +181,7 @@ type XMRTaker interface {
 // XMRMaker ...
 type XMRMaker interface {
 	Protocol
-	MakeOffer(offer *types.Offer, relayerEndpoint string, relayerCommission *apd.Decimal) (*types.OfferExtra, error)
+	MakeOffer(offer *types.Offer, relayerEndpoint string, relayerFee *apd.Decimal) (*types.OfferExtra, error)
 	GetOffers() []*types.Offer
 	ClearOffers([]types.Hash) error
 	GetMoneroBalance() (string, *wallet.GetBalanceResponse, error)

--- a/rpcclient/make_offer.go
+++ b/rpcclient/make_offer.go
@@ -15,19 +15,19 @@ func (c *Client) MakeOffer(
 	exchangeRate *coins.ExchangeRate,
 	ethAsset types.EthAsset,
 	relayerEndpoint string,
-	relayerCommission *apd.Decimal,
+	relayerFee *apd.Decimal,
 ) (*rpctypes.MakeOfferResponse, error) {
 	const (
 		method = "net_makeOffer"
 	)
 
 	req := &rpctypes.MakeOfferRequest{
-		MinAmount:         min,
-		MaxAmount:         max,
-		ExchangeRate:      exchangeRate,
-		EthAsset:          ethcommon.Address(ethAsset).Hex(),
-		RelayerEndpoint:   relayerEndpoint,
-		RelayerCommission: relayerCommission,
+		MinAmount:       min,
+		MaxAmount:       max,
+		ExchangeRate:    exchangeRate,
+		EthAsset:        ethcommon.Address(ethAsset).Hex(),
+		RelayerEndpoint: relayerEndpoint,
+		RelayerFee:      relayerFee,
 	}
 	res := &rpctypes.MakeOfferResponse{}
 

--- a/rpcclient/wsclient/wsclient.go
+++ b/rpcclient/wsclient/wsclient.go
@@ -37,7 +37,7 @@ type WsClient interface {
 		exchangeRate *coins.ExchangeRate,
 		ethAsset types.EthAsset,
 		relayerEndpoint string,
-		relayerCommission *apd.Decimal,
+		relayerFee *apd.Decimal,
 	) (*rpctypes.MakeOfferResponse, <-chan types.Status, error)
 }
 
@@ -328,15 +328,15 @@ func (c *wsClient) MakeOfferAndSubscribe(
 	exchangeRate *coins.ExchangeRate,
 	ethAsset types.EthAsset,
 	relayerEndpoint string,
-	relayerCommission *apd.Decimal,
+	relayerFee *apd.Decimal,
 ) (*rpctypes.MakeOfferResponse, <-chan types.Status, error) {
 	params := &rpctypes.MakeOfferRequest{
-		MinAmount:         min,
-		MaxAmount:         max,
-		ExchangeRate:      exchangeRate,
-		EthAsset:          ethAsset.Address().String(),
-		RelayerEndpoint:   relayerEndpoint,
-		RelayerCommission: relayerCommission,
+		MinAmount:       min,
+		MaxAmount:       max,
+		ExchangeRate:    exchangeRate,
+		EthAsset:        ethAsset.Address().String(),
+		RelayerEndpoint: relayerEndpoint,
+		RelayerFee:      relayerFee,
 	}
 
 	bz, err := vjson.MarshalStruct(params)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -172,7 +172,7 @@ func (s *IntegrationTestSuite) TestSuccess_OneSwap() {
 func (s *IntegrationTestSuite) testSuccessOneSwap(
 	asset types.EthAsset,
 	relayerEndpoint string,
-	relayerCommission *apd.Decimal,
+	relayerFee *apd.Decimal,
 ) {
 	const testTimeout = time.Second * 90
 
@@ -182,7 +182,7 @@ func (s *IntegrationTestSuite) testSuccessOneSwap(
 	bwsc := s.newSwapdWSClient(ctx, defaultXMRMakerSwapdWSEndpoint)
 	min := coins.StrToDecimal("0.1")
 	offerResp, statusCh, err := bwsc.MakeOfferAndSubscribe(min, xmrmakerProvideAmount,
-		exchangeRate, asset, relayerEndpoint, relayerCommission)
+		exchangeRate, asset, relayerEndpoint, relayerFee)
 	require.NoError(s.T(), err)
 
 	bc := rpcclient.NewClient(ctx, defaultXMRMakerSwapdEndpoint)

--- a/tests/relayer_integration_test.go
+++ b/tests/relayer_integration_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/athanorlabs/atomic-swap/coins"
+	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	"github.com/athanorlabs/atomic-swap/rpcclient"
 )
@@ -15,18 +15,18 @@ const (
 )
 
 var (
-	relayerCommission = coins.StrToDecimal("0.01")
+	relayerFee = common.DefaultRelayerFee
 )
 
 func (s *IntegrationTestSuite) Test_Success_ClaimRelayer() {
-	s.testSuccessOneSwap(types.EthAssetETH, defaultRelayerEndpoint, relayerCommission)
+	s.testSuccessOneSwap(types.EthAssetETH, defaultRelayerEndpoint, relayerFee)
 }
 
 func (s *IntegrationTestSuite) TestERC20_Success_ClaimRelayer() {
 	s.testSuccessOneSwap(
 		types.EthAsset(deployERC20Mock(s.T())),
 		defaultRelayerEndpoint,
-		relayerCommission,
+		relayerFee,
 	)
 }
 
@@ -42,5 +42,5 @@ func (s *IntegrationTestSuite) TestXMRMaker_DiscoverRelayer() {
 
 func (s *IntegrationTestSuite) Test_Success_ClaimRelayer_P2p() {
 	// use fake endpoint, this will cause the node to fallback to the p2p layer
-	s.testSuccessOneSwap(types.EthAssetETH, "http://127.0.0.1:9090", relayerCommission)
+	s.testSuccessOneSwap(types.EthAssetETH, "http://127.0.0.1:9090", relayerFee)
 }


### PR DESCRIPTION
- update relayer fee to be a fixed value instead of swap percentage
- update default fee to be 0.009 ETH 
- change all usages of `relayerCommission` -> `relayerFee`

closes #293