### PR TITLE
feat: add start/end times to `swap.Info` and swap RPC returns

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -662,6 +662,7 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 			receivedCoin = "XMR"
 		}
 
+		fmt.Printf("ID: %s\n", info.ID)
 		fmt.Printf("Start time: %s\n", info.StartTime)
 		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
 		fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -292,9 +292,9 @@ var (
 				},
 			},
 			{
-				Name:   "get-stage",
-				Usage:  "Get the stage of a current swap.",
-				Action: runGetStage,
+				Name:   "get-status",
+				Usage:  "Get the status of a current swap.",
+				Action: runGetStatus,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:     flagOfferID,
@@ -677,8 +677,8 @@ func runGetPastSwapIDs(ctx *cli.Context) error {
 		}
 
 		fmt.Printf("ID: %s\n", id.ID)
-		fmt.Printf("Start time: %s\n", id.StartTime)
-		fmt.Printf("End time: %s\n", id.EndTime)
+		fmt.Printf("Start time: %s\n", id.StartTime.Format(common.TimeFmtSecs))
+		fmt.Printf("End time: %s\n", id.EndTime.Format(common.TimeFmtSecs))
 	}
 
 	return nil
@@ -710,8 +710,8 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 		}
 
 		fmt.Printf("ID: %s\n", info.ID)
-		fmt.Printf("Start time: %s\n", info.StartTime)
-		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
+		fmt.Printf("Start time: %s\n", info.StartTime.Format(common.TimeFmtSecs))
+		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount, info.Provided)
 		fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
 		fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
 		fmt.Printf("Status: %s\n", info.Status)
@@ -734,9 +734,9 @@ func runGetPastSwap(ctx *cli.Context) error {
 		receivedCoin = "XMR"
 	}
 
-	fmt.Printf("Start time: %s\n", info.StartTime)
-	fmt.Printf("End time: %s\n", info.EndTime)
-	fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
+	fmt.Printf("Start time: %s\n", info.StartTime.Format(common.TimeFmtSecs))
+	fmt.Printf("End time: %s\n", info.EndTime.Format(common.TimeFmtSecs))
+	fmt.Printf("Provided: %s %s\n", info.ProvidedAmount, info.Provided)
 	fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
 	fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
 	fmt.Printf("Status: %s\n", info.Status)
@@ -826,17 +826,20 @@ func runGetOffers(ctx *cli.Context) error {
 	return nil
 }
 
-func runGetStage(ctx *cli.Context) error {
-	offerID := ctx.String(flagOfferID)
+func runGetStatus(ctx *cli.Context) error {
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
 
 	c := newRRPClient(ctx)
-	resp, err := c.GetStage(offerID)
+	resp, err := c.GetStatus(offerID)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Start time: %s\n", resp.StartTime)
-	fmt.Printf("Stage=%s: %s\n", resp.Stage, resp.Info)
+	fmt.Printf("Start time: %s\n", resp.StartTime.Format(common.TimeFmtSecs))
+	fmt.Printf("Status=%s: %s\n", resp.Status, resp.Info)
 	return nil
 }
 

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -630,7 +630,7 @@ func runGetPastSwapIDs(ctx *cli.Context) error {
 			fmt.Printf("---\n")
 		}
 
-		fmt.Printf("ID: %s\n", id)
+		fmt.Printf("ID: %s\n", id.ID)
 		fmt.Printf("Start time: %s\n", id.StartTime)
 		fmt.Printf("End time: %s\n", id.EndTime)
 	}
@@ -642,21 +642,33 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 	offerID := ctx.String(flagOfferID)
 
 	c := newRRPClient(ctx)
-	info, err := c.GetOngoingSwap(offerID)
+	resp, err := c.GetOngoingSwap(offerID)
 	if err != nil {
 		return err
 	}
 
-	receivedCoin := "ETH"
-	if info.Provided == coins.ProvidesETH {
-		receivedCoin = "XMR"
+	fmt.Println("Ongoing swaps:")
+	if len(resp.Swaps) == 0 {
+		fmt.Println("[none]")
+		return nil
 	}
 
-	fmt.Printf("Start time: %s\n", info.StartTime)
-	fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
-	fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
-	fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
-	fmt.Printf("Status: %s\n", info.Status)
+	for i, info := range resp.Swaps {
+		if i > 0 {
+			fmt.Printf("---\n")
+		}
+
+		receivedCoin := "ETH"
+		if info.Provided == coins.ProvidesETH {
+			receivedCoin = "XMR"
+		}
+
+		fmt.Printf("Start time: %s\n", info.StartTime)
+		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
+		fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
+		fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
+		fmt.Printf("Status: %s\n", info.Status)
+	}
 
 	return nil
 }

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -206,13 +206,12 @@ var (
 			},
 			{
 				Name:   "get-ongoing-swap",
-				Usage:  "Get information about ongoing swap, if there is one",
+				Usage:  "Get information about ongoing swap(s).",
 				Action: runGetOngoingSwap,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap to retrieve info for",
-						Required: true,
+						Name:  flagOfferID,
+						Usage: "ID of swap to retrieve info for",
 					},
 					swapdPortFlag,
 				},

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -620,12 +620,21 @@ func runGetPastSwapIDs(ctx *cli.Context) error {
 	}
 
 	fmt.Println("Past swap offer IDs:")
-	for i, id := range ids {
-		fmt.Printf("%d: %s\n", i, id)
-	}
 	if len(ids) == 0 {
 		fmt.Println("[none]")
+		return nil
 	}
+
+	for i, id := range ids {
+		if i > 0 {
+			fmt.Printf("---\n")
+		}
+
+		fmt.Printf("ID: %s\n", id)
+		fmt.Printf("Start time: %s\n", id.StartTime)
+		fmt.Printf("End time: %s\n", id.EndTime)
+	}
+
 	return nil
 }
 
@@ -643,6 +652,7 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 		receivedCoin = "XMR"
 	}
 
+	fmt.Printf("Start time: %s\n", info.StartTime)
 	fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
 	fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
 	fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
@@ -665,6 +675,8 @@ func runGetPastSwap(ctx *cli.Context) error {
 		receivedCoin = "XMR"
 	}
 
+	fmt.Printf("Start time: %s\n", info.StartTime)
+	fmt.Printf("End time: %s\n", info.EndTime)
 	fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
 	fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount, receivedCoin)
 	fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
@@ -764,6 +776,7 @@ func runGetStage(ctx *cli.Context) error {
 		return err
 	}
 
+	fmt.Printf("Start time: %s\n", resp.StartTime)
 	fmt.Printf("Stage=%s: %s\n", resp.Stage, resp.Info)
 	return nil
 }

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -385,7 +385,7 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 Gets information for the specified ongoing swap.
 
 Parameters:
-- `offerID`: optional: the swap's ID.
+- `offerID`: (optional) the swap's ID.
 
 Returns:
 - `swaps`: a list of ongoing swaps. If an offerID is provided, this returns only the swap with that ID, if it exists.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -9,7 +9,7 @@ with the swap network and make/take swap offers.
 
 Get the local libp2p listening addresses of the node. Unless you have a public IP
 directly attached to your host, these are not the addresses that remote hosts will
-directly connect to.- `startTime`: the start time of the swap.
+directly connect to.
 
 
 Parameters:
@@ -392,7 +392,7 @@ Returns:
 
 Each items in `swaps` contains:
 - `id`: the swap ID.
-- `startTime`: the start time of the swap.
+- `startTime`: the start time of the swap (in RFC 3339 format).
 - `provided`: the coin provided during the swap.
 - `providedAmount`: the amount of coin provided during the swap.
 - `receivedAmount`: the amount of coin expected to be received during the swap.
@@ -471,8 +471,8 @@ Returns:
 
 Each item in `ids` contains:
 - `id`: the ID of the swap.
-- `startTime`: the start time of the swap.
-- `endTime`: the end time of the swap.
+- `startTime`: the start time of the swap (in RFC 3339 format).
+- `endTime`: the end time of the swap (in RFC 3339 format).
 
 Example:
 ```bash
@@ -535,9 +535,9 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 }
 ```
 
-### `swap_getStage`
+### `swap_getStatus`
 
-Gets the stage of an ongoing swap.
+Gets the status of an ongoing swap.
 
 Parameters:
 - `id`: id of the swap to get the stage of
@@ -545,20 +545,20 @@ Parameters:
 Returns:
 - `stage`: stage of the swap
 - `info`: description of the swap's stage
-- `startTime`: the start time of the swap.
+- `startTime`: the start time of the swap (in RFC 3339 format).
 
 Example:
 ```bash
 curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
-'{"jsonrpc":"2.0","id":"0","method":"swap_getStage",
-"params":{"offerID": "0xbe6cb622906510e69339fa5d8e7d60c90bad762deb8d06985466dd9144809040"}}' \
+'{"jsonrpc":"2.0","id":"0","method":"swap_getStatus",
+"params":{"id": "0xbe6cb622906510e69339fa5d8e7d60c90bad762deb8d06985466dd9144809040"}}' \
 | jq
 ```
 ```json
 {
   "jsonrpc": "2.0",
   "result": {
-    "stage": "ETHLocked",
+    "status": "ETHLocked",
     "info": "the ETH provider has locked their ether, but no XMR has been locked",
     "startTime": "2023-02-20T23:52:28.826764666Z"
   },
@@ -574,9 +574,9 @@ Parameters:
 - none
 
 Returns:
-- `ethUpdatedAt`: time when the ETH price was last updated (RFC 3339 format).
+- `ethUpdatedAt`: time when the ETH price was last updated (in RFC 3339 format).
 - `ethPrice`: current ETH/USD price (max 8 decimal points).
-- `xmrUpdatedAt`: time when the XMR price was last updated (RFC 3339 format).
+- `xmrUpdatedAt`: time when the XMR price was last updated (in RFC 3339 format).
 - `xmrPrice`: the current XMR/USD price (max 8 decimal points).
 - `exchangeRate`: the exchange rate expressed as the XMR/ETH price ratio.
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -9,7 +9,8 @@ with the swap network and make/take swap offers.
 
 Get the local libp2p listening addresses of the node. Unless you have a public IP
 directly attached to your host, these are not the addresses that remote hosts will
-directly connect to.
+directly connect to.- `startTime`: the start time of the swap.
+
 
 Parameters:
 - none
@@ -384,9 +385,14 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 Gets information for the specified ongoing swap.
 
 Parameters:
-- `offerID`: the swap's ID.
+- `offerID`: optional: the swap's ID.
 
 Returns:
+- `swaps`: a list of ongoing swaps. If an offerID is provided, this returns only the swap with that ID, if it exists.
+
+Each items in `swaps` contains:
+- `id`: the swap ID.
+- `startTime`: the start time of the swap.
 - `provided`: the coin provided during the swap.
 - `providedAmount`: the amount of coin provided during the swap.
 - `receivedAmount`: the amount of coin expected to be received during the swap.
@@ -403,11 +409,51 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 {
   "jsonrpc": "2.0",
   "result": {
-    "provided": "ETH",
-    "providedAmount": "0.01",
-    "receivedAmount": "1",
-    "exchangeRate": "0.01",
-    "status": "ETHLocked"
+    "swaps": [
+      {
+        "id": "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381",
+        "provided": "ETH",
+        "providedAmount": "0.18",
+        "expectedAmount": "0.18",
+        "exchangeRate": "1",
+        "status": "ETHLocked",
+        "startTime": "2023-02-20T23:52:28.826764666Z"
+      }
+    ]
+  },
+  "id": "0"
+}
+```
+
+To get all ongoing swaps:
+```bash
+curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
+'{"jsonrpc":"2.0","id":"0","method":"swap_getOngoing","params":{}}' | jq
+```
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "swaps": [
+      {
+        "id": "0xea9e976d11871627c8fed3f15e0ec3857364d61c632cbf9f1da4dca603397c4f",
+        "provided": "ETH",
+        "providedAmount": "0.14",
+        "expectedAmount": "0.14",
+        "exchangeRate": "1",
+        "status": "ETHLocked",
+        "startTime": "2023-02-20T22:01:24.145265256Z"
+      },
+      {
+        "id": "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381",
+        "provided": "ETH",
+        "providedAmount": "0.18",
+        "expectedAmount": "0.18",
+        "exchangeRate": "1",
+        "status": "ETHLocked",
+        "startTime": "2023-02-20T23:52:28.826764666Z"
+      }
+    ]
   },
   "id": "0"
 }
@@ -423,6 +469,11 @@ Parameters:
 Returns:
 - `ids`: a list of all past swap IDs.
 
+Each item in `ids` contains:
+- `id`: the ID of the swap.
+- `startTime`: the start time of the swap.
+- `endTime`: the end time of the swap.
+
 Example:
 ```bash
 curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
@@ -433,11 +484,16 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
   "jsonrpc": "2.0",
   "result": {
     "ids": [
-      "0x6ca19b496426bfbb97ccab16473db4cf50faf77074809701c8478afe7d8370d9",
-      "0x9549685d15cd9a136111db755e5440b4c95e266ba39dc0c84834714d185dc6f0",
-      "0xa55ba276c4c6bc77713776cd50fa2d20d31b8b26ed67be458e0c1a5794721587",
-      "0x2ed05e12ecd45d992b523ee52a516f51d15480d4b7805a29733f9f000efc17d3",
-      "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381"
+      {
+        "id": "0x25d567ce6d963750e17946905bb334580b9e469c8f23e724ab98df535277dcc2",
+        "startTime": "2023-02-20T21:56:44.006075694Z",
+        "endTime": "2023-02-20T21:56:47.023332658Z"
+      },
+      {
+        "id": "0x38083ead32b9278c71ec6225b11d12aa6aaa677992afe415f26b4648572b4206",
+        "startTime": "2023-02-20T21:14:02.04949932Z",
+        "endTime": "2023-02-20T21:36:21.362943839Z"
+      }
     ]
   },
   "id": "0"
@@ -489,10 +545,11 @@ Parameters:
 Returns:
 - `stage`: stage of the swap
 - `info`: description of the swap's stage
+- `startTime`: the start time of the swap.
 
 Example:
 ```bash
-curl -s -X POST http://127.0.0.1:5001 -H 'Content-Type: application/json' -d \
+curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 '{"jsonrpc":"2.0","id":"0","method":"swap_getStage",
 "params":{"offerID": "0xbe6cb622906510e69339fa5d8e7d60c90bad762deb8d06985466dd9144809040"}}' \
 | jq
@@ -501,8 +558,9 @@ curl -s -X POST http://127.0.0.1:5001 -H 'Content-Type: application/json' -d \
 {
   "jsonrpc": "2.0",
   "result": {
-    "stage": "KeysExchanged",
-    "info": "keys have been exchanged, but no value has been locked"
+    "stage": "ETHLocked",
+    "info": "the ETH provider has locked their ether, but no XMR has been locked",
+    "startTime": "2023-02-20T23:52:28.826764666Z"
   },
   "id": "0"
 }

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -5,6 +5,7 @@ package swap
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/athanorlabs/atomic-swap/common/types"
 
@@ -170,6 +171,8 @@ func (m *manager) CompleteOngoingSwap(info *Info) error {
 	if !has {
 		return errNoSwapWithID
 	}
+
+	info.EndTime = time.Now()
 
 	m.past[info.ID] = info
 	delete(m.ongoing, info.ID)

--- a/protocol/swap/types.go
+++ b/protocol/swap/types.go
@@ -64,7 +64,7 @@ func NewInfo(
 		Status:            status,
 		MoneroStartHeight: moneroStartHeight,
 		statusCh:          statusCh,
-		StartTime: time.Now(),
+		StartTime:         time.Now(),
 	}
 	return info
 }

--- a/protocol/swap/types.go
+++ b/protocol/swap/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/cockroachdb/apd/v3"
@@ -35,6 +36,8 @@ type Info struct {
 	Status         Status              `json:"status"`
 	// MoneroStartHeight is the Monero block number when the swap begins.
 	MoneroStartHeight uint64            `json:"moneroStartHeight"`
+	StartTime         time.Time         `json:"startTime"`
+	EndTime           time.Time         `json:"endTime"`
 	statusCh          chan types.Status `json:"-"`
 }
 
@@ -61,6 +64,7 @@ func NewInfo(
 		Status:            status,
 		MoneroStartHeight: moneroStartHeight,
 		statusCh:          statusCh,
+		StartTime: time.Now(),
 	}
 	return info
 }

--- a/protocol/swap/types_test.go
+++ b/protocol/swap/types_test.go
@@ -27,8 +27,12 @@ func Test_InfoMarshal(t *testing.T) {
 		200,
 		make(chan types.Status),
 	)
+	err := info.StartTime.UnmarshalJSON([]byte("\"2023-02-20T17:29:43.471020297-05:00\""))
+	require.NoError(t, err)
+
 	infoBytes, err := vjson.MarshalStruct(info)
 	require.NoError(t, err)
+
 	expectedJSON := `{
 		"version": "0.2.0",
 		"offerID": "0x0102030405060708091011121314151617181920212223242526272829303132",
@@ -38,7 +42,9 @@ func Test_InfoMarshal(t *testing.T) {
 		"exchangeRate": "0.33",
 		"ethAsset": "ETH",
 		"moneroStartHeight": 200,
-		"status": 5
+		"status": 5,
+		"startTime": "2023-02-20T17:29:43.471020297-05:00",
+		"endTime":"0001-01-01T00:00:00Z"
 	}`
 	require.JSONEq(t, expectedJSON, string(infoBytes))
 }

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -96,7 +96,7 @@ func (inst *Instance) checkForOngoingSwaps() error {
 		}
 
 		if s.Status == types.KeysExchanged || s.Status == types.ExpectingKeys {
-			log.Info("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
+			log.Infof("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
 
 			// for these two cases, no funds have been locked, so we can safely
 			// abort the swap.
@@ -129,7 +129,7 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 }
 
 func (inst *Instance) createOngoingSwap(s *swap.Info) error {
-	log.Info("found ongoing swap %s in DB, restarting swap", s.ID)
+	log.Infof("found ongoing swap %s in DB, restarting swap", s.ID)
 
 	// check if we have shared secret key in db; if so, recover XMR from that
 	// otherwise, create new swap state from recovery info

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -96,6 +96,8 @@ func (inst *Instance) checkForOngoingSwaps() error {
 		}
 
 		if s.Status == types.KeysExchanged || s.Status == types.ExpectingKeys {
+			log.Info("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
+
 			// for these two cases, no funds have been locked, so we can safely
 			// abort the swap.
 			err = inst.abortOngoingSwap(s)
@@ -127,6 +129,8 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 }
 
 func (inst *Instance) createOngoingSwap(s *swap.Info) error {
+	log.Info("found ongoing swap %s in DB, restarting swap", s.ID)
+
 	// check if we have shared secret key in db; if so, recover XMR from that
 	// otherwise, create new swap state from recovery info
 	skA, err := inst.backend.RecoveryDB().GetCounterpartySwapPrivateKey(s.ID)

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -77,6 +77,7 @@ func (inst *Instance) checkForOngoingSwaps() error {
 
 		if s.Status == types.KeysExchanged || s.Status == types.ExpectingKeys {
 			// set status to aborted, delete info from recovery db
+			log.Info("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
 			err = inst.abortOngoingSwap(s)
 			if err != nil {
 				log.Warnf("failed to abort ongoing swap %s: %s", s.ID, err)
@@ -105,6 +106,8 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 }
 
 func (inst *Instance) createOngoingSwap(s *swap.Info) error {
+	log.Info("found ongoing swap %s in DB, restarting swap", s.ID)
+
 	// check if we have shared secret key in db; if so, claim XMR from that
 	// otherwise, create new swap state from recovery info
 	skB, err := inst.backend.RecoveryDB().GetCounterpartySwapPrivateKey(s.ID)

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -77,7 +77,7 @@ func (inst *Instance) checkForOngoingSwaps() error {
 
 		if s.Status == types.KeysExchanged || s.Status == types.ExpectingKeys {
 			// set status to aborted, delete info from recovery db
-			log.Info("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
+			log.Infof("found ongoing swap %s in DB, aborting since no funds were locked", s.ID)
 			err = inst.abortOngoingSwap(s)
 			if err != nil {
 				log.Warnf("failed to abort ongoing swap %s: %s", s.ID, err)
@@ -106,7 +106,7 @@ func (inst *Instance) abortOngoingSwap(s *swap.Info) error {
 }
 
 func (inst *Instance) createOngoingSwap(s *swap.Info) error {
-	log.Info("found ongoing swap %s in DB, restarting swap", s.ID)
+	log.Infof("found ongoing swap %s in DB, restarting swap", s.ID)
 
 	// check if we have shared secret key in db; if so, claim XMR from that
 	// otherwise, create new swap state from recovery info

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -47,9 +47,9 @@ func NewSwapService(
 
 // PastSwapInfo contains a swap ID and its start and end time.
 type PastSwapInfo struct {
-	ID string `json:"id"`
+	ID        string    `json:"id"`
 	StartTime time.Time `json:"startTime"`
-	EndTime time.Time `json:"endTime"`
+	EndTime   time.Time `json:"endTime"`
 }
 
 // GetPastIDsResponse ...
@@ -73,9 +73,9 @@ func (s *SwapService) GetPastIDs(_ *http.Request, _ *interface{}, resp *GetPastI
 		}
 
 		resp.IDs[i] = &PastSwapInfo{
-			ID: id.String(),
+			ID:        id.String(),
 			StartTime: info.StartTime,
-			EndTime: info.EndTime,
+			EndTime:   info.EndTime,
 		}
 	}
 
@@ -98,8 +98,8 @@ type GetPastResponse struct {
 	ExpectedAmount *apd.Decimal        `json:"expectedAmount"`
 	ExchangeRate   *coins.ExchangeRate `json:"exchangeRate"`
 	Status         string              `json:"status"`
-	StartTime time.Time `json:"startTime"`
-	EndTime time.Time `json:"endTime"`
+	StartTime      time.Time           `json:"startTime"`
+	EndTime        time.Time           `json:"endTime"`
 }
 
 // GetPast returns information about a past swap, given its ID.
@@ -131,7 +131,7 @@ type GetOngoingResponse struct {
 	ExpectedAmount *apd.Decimal        `json:"expectedAmount"`
 	ExchangeRate   *coins.ExchangeRate `json:"exchangeRate"`
 	Status         string              `json:"status"`
-	StartTime time.Time `json:"startTime"`
+	StartTime      time.Time           `json:"startTime"`
 }
 
 // GetOngoingRequest ...
@@ -203,8 +203,8 @@ type GetStageRequest struct {
 
 // GetStageResponse ...
 type GetStageResponse struct {
-	Stage string `json:"stage"`
-	Info  string `json:"info"`
+	Stage     string    `json:"stage"`
+	Info      string    `json:"info"`
 	StartTime time.Time `json:"startTime"`
 }
 

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -127,6 +127,7 @@ func (s *SwapService) GetPast(_ *http.Request, req *GetPastRequest, resp *GetPas
 
 // OngoingSwap represents an ongoing swap returned by swap_getOngoing.
 type OngoingSwap struct {
+	ID             types.Hash          `json:"id"`
 	Provided       coins.ProvidesCoin  `json:"provided"`
 	ProvidedAmount *apd.Decimal        `json:"providedAmount"`
 	ExpectedAmount *apd.Decimal        `json:"expectedAmount"`
@@ -173,14 +174,20 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 
 	resp.Swaps = make([]*OngoingSwap, len(swaps))
 	for i, info := range swaps {
-		resp.Swaps[i] = new(OngoingSwap)
-		resp.Swaps[i].Provided = info.Provides
-		resp.Swaps[i].ProvidedAmount = info.ProvidedAmount
-		resp.Swaps[i].ExpectedAmount = info.ExpectedAmount
-		resp.Swaps[i].ExchangeRate = info.ExchangeRate
-		resp.Swaps[i].Status = info.Status.String()
-		resp.Swaps[i].StartTime = info.StartTime
+		swap := new(OngoingSwap)
+		swap.ID = info.ID
+		swap.Provided = info.Provides
+		swap.ProvidedAmount = info.ProvidedAmount
+		swap.ExpectedAmount = info.ExpectedAmount
+		swap.ExchangeRate = info.ExchangeRate
+		swap.Status = info.Status.String()
+		swap.StartTime = info.StartTime
+		resp.Swaps[i] = swap
 	}
+
+	sort.Slice(resp.Swaps, func(i, j int) bool {
+		return resp.Swaps[i].StartTime.UnixNano() > resp.Swaps[j].StartTime.UnixNano()
+	})
 
 	return nil
 }

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -173,6 +173,7 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 
 	resp.Swaps = make([]*OngoingSwap, len(swaps))
 	for i, info := range swaps {
+		resp.Swaps[i] = new(OngoingSwap)
 		resp.Swaps[i].Provided = info.Provides
 		resp.Swaps[i].ProvidedAmount = info.ProvidedAmount
 		resp.Swaps[i].ExpectedAmount = info.ExpectedAmount

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -81,7 +81,7 @@ func (s *SwapService) GetPastIDs(_ *http.Request, _ *interface{}, resp *GetPastI
 	}
 
 	sort.Slice(resp.Swaps, func(i, j int) bool {
-		return resp.Swaps[i].StartTime.UnixNano() > resp.Swaps[j].StartTime.UnixNano()
+		return resp.Swaps[i].StartTime.UnixNano() < resp.Swaps[j].StartTime.UnixNano()
 	})
 
 	return nil
@@ -186,7 +186,7 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 	}
 
 	sort.Slice(resp.Swaps, func(i, j int) bool {
-		return resp.Swaps[i].StartTime.UnixNano() > resp.Swaps[j].StartTime.UnixNano()
+		return resp.Swaps[i].StartTime.UnixNano() < resp.Swaps[j].StartTime.UnixNano()
 	})
 
 	return nil

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetPastSwapIDs calls swap_getPastIDs
-func (c *Client) GetPastSwapIDs() ([]string, error) {
+func (c *Client) GetPastSwapIDs() ([]*rpc.PastSwapInfo, error) {
 	const (
 		method = "swap_getPastIDs"
 	)

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -19,7 +19,7 @@ func (c *Client) GetPastSwapIDs() ([]*rpc.PastSwapInfo, error) {
 		return nil, err
 	}
 
-	return res.IDs, nil
+	return res.Swaps, nil
 }
 
 // GetOngoingSwap calls swap_getOngoing
@@ -77,16 +77,16 @@ func (c *Client) Refund(id string) (*rpc.RefundResponse, error) {
 	return res, nil
 }
 
-// GetStage calls swap_getStage
-func (c *Client) GetStage(id string) (*rpc.GetStageResponse, error) {
+// GetStatus calls swap_getStatus
+func (c *Client) GetStatus(id types.Hash) (*rpc.GetStatusResponse, error) {
 	const (
-		method = "swap_getStage"
+		method = "swap_getStatus"
 	)
 
-	req := &rpc.GetStageRequest{
-		OfferID: id,
+	req := &rpc.GetStatusRequest{
+		ID: id,
 	}
-	res := &rpc.GetStageResponse{}
+	res := &rpc.GetStatusResponse{}
 
 	if err := c.Post(method, req, res); err != nil {
 		return nil, err


### PR DESCRIPTION
-  add start/end times to `swap.Info`
- update `swap_getPastIDs` to return start/end times also and sort by start time
- update other swap RPC getters to return swap start times
- also update `swap_getOngoing` to return all ongoing swaps if no ID is provided

closes #222 