### PR TITLE
feat: add `--check-code` flag to toggle code check on startup

### DIFF
--- a/cmd/swapd/contract.go
+++ b/cmd/swapd/contract.go
@@ -57,10 +57,10 @@ func getOrDeploySwapFactory(
 		}
 		log.Infof("loaded SwapFactory.sol from address %s", address)
 
-		_, err = contracts.CheckSwapFactoryContractCode(ctx, ec, address)
-		if err != nil {
-			return nil, ethcommon.Address{}, err
-		}
+		// _, err = contracts.CheckSwapFactoryContractCode(ctx, ec, address)
+		// if err != nil {
+		// 	return nil, ethcommon.Address{}, err
+		// }
 	}
 
 	return sf, address, nil

--- a/cmd/swapd/contract.go
+++ b/cmd/swapd/contract.go
@@ -34,6 +34,7 @@ func getOrDeploySwapFactory(
 	privkey *ecdsa.PrivateKey,
 	ec *ethclient.Client,
 	forwarderAddress ethcommon.Address,
+	withCodeCheck bool,
 ) (*contracts.SwapFactory, ethcommon.Address, error) {
 	var (
 		sf  *contracts.SwapFactory
@@ -57,10 +58,14 @@ func getOrDeploySwapFactory(
 		}
 		log.Infof("loaded SwapFactory.sol from address %s", address)
 
-		// _, err = contracts.CheckSwapFactoryContractCode(ctx, ec, address)
-		// if err != nil {
-		// 	return nil, ethcommon.Address{}, err
-		// }
+		if !withCodeCheck {
+			return sf, address, nil
+		}
+
+		_, err = contracts.CheckSwapFactoryContractCode(ctx, ec, address)
+		if err != nil {
+			return nil, ethcommon.Address{}, err
+		}
 	}
 
 	return sf, address, nil

--- a/cmd/swapd/contract_test.go
+++ b/cmd/swapd/contract_test.go
@@ -28,6 +28,7 @@ func TestGetOrDeploySwapFactory_DeployNoForwarder(t *testing.T) {
 		pk,
 		ec,
 		forwarder,
+		true,
 	)
 	require.NoError(t, err)
 }
@@ -45,6 +46,7 @@ func TestGetOrDeploySwapFactory_DeployForwarderAlso(t *testing.T) {
 		pk,
 		ec,
 		ethcommon.Address{},
+		true,
 	)
 	require.NoError(t, err)
 }
@@ -67,6 +69,7 @@ func TestGetOrDeploySwapFactory_Get(t *testing.T) {
 		pk,
 		ec,
 		forwarder,
+		true,
 	)
 	require.NoError(t, err)
 
@@ -78,6 +81,7 @@ func TestGetOrDeploySwapFactory_Get(t *testing.T) {
 		pk,
 		ec,
 		ethcommon.Address{},
+		true,
 	)
 	require.NoError(t, err)
 	require.Equal(t, address, addr2)

--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -76,6 +76,7 @@ const (
 	flagGasPrice             = "gas-price"
 	flagGasLimit             = "gas-limit"
 	flagUseExternalSigner    = "external-signer"
+	flagWithCodeCheck        = "check-code"
 
 	flagDevXMRTaker      = "dev-xmrtaker"
 	flagDevXMRMaker      = "dev-xmrmaker"
@@ -207,6 +208,11 @@ var (
 				Name:   flagProfile,
 				Usage:  "BIND_IP:PORT to provide profiling information on",
 				Hidden: true, // flag is only for developers
+			},
+			&cli.BoolFlag{
+				Name:  flagWithCodeCheck,
+				Usage: "Check if contract code matches expected code at startup. Defaults to true.",
+				Value: true,
 			},
 		},
 	}
@@ -646,6 +652,7 @@ func newBackend(
 		ethPrivKey,
 		ec,
 		forwarderAddress,
+		c.Bool(flagWithCodeCheck),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- add `--check-code` flag to toggle code check on startup; defaults to true
- I added this because I was stuck in the case where the daemon starts up with updated contract code, but there was an ongoing swap that needed to be completed, but it couldn't because the contract code didn't match:
```
2023-02-20T21:08:35.469Z	ERROR	cmd	swapd/main.go:293	RPC/Websocket server exited: failed to create new swap state for ongoing swap, id 0xc89fbbfc5ccb11d6ba3336da554bebcb6e6d981a9e7f79d7b682905741c98bdb: cannot recover from swap where contract address is not the one loaded at start-up; please restart with --contract-address=0xaEc2Db3B24fab372AE93bA56f55F01B522C1Ee13
```

- but then starting the daemon with the above `--contract-address` fails because of the code check on startup.
- the easiest way to fix this was to add a flag to disable the code check

let me know if this is an adequate solution, or if there's another method you'd prefer.