### PR TITLE
fix: ensure stage is changed if funds are locked, even in error case

### DIFF
--- a/protocol/xmrmaker/event.go
+++ b/protocol/xmrmaker/event.go
@@ -190,15 +190,17 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.setNextExpectedEvent(EventContractReadyType)
-		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventContractReadyType: %w", err)
-			return
-		}
-
-		err = s.handleEventETHLocked(e)
+		err := s.handleEventETHLocked(e)
 		if err != nil {
 			e.errCh <- fmt.Errorf("failed to handle EventETHLocked: %w", err)
+			if !s.fundsLocked {
+				return
+			}
+		}
+
+		err = s.setNextExpectedEvent(EventContractReadyType)
+		if err != nil {
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventContractReadyType: %w", err)
 			return
 		}
 	case *EventContractReady:

--- a/protocol/xmrmaker/event.go
+++ b/protocol/xmrmaker/event.go
@@ -190,15 +190,15 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventETHLocked(e)
+		err := s.setNextExpectedEvent(EventContractReadyType)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to handle EventETHLocked: %w", err)
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventContractReadyType: %w", err)
 			return
 		}
 
-		err = s.setNextExpectedEvent(EventContractReadyType)
+		err = s.handleEventETHLocked(e)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventContractReadyType: %w", err)
+			e.errCh <- fmt.Errorf("failed to handle EventETHLocked: %w", err)
 			return
 		}
 	case *EventContractReady:

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -71,6 +71,8 @@ type swapState struct {
 
 	// tracks the state of the swap
 	nextExpectedEvent EventType
+	// set to true once funds are locked
+	fundsLocked bool
 
 	// channels
 
@@ -529,6 +531,7 @@ func (s *swapState) lockFunds(amount *coins.PiconeroAmount) (*message.NotifyXMRL
 	}
 	log.Infof("Successfully locked XMR funds: txID=%s address=%s block=%d",
 		transfer.TxID, swapDestAddr, transfer.Height)
+	s.fundsLocked = true
 
 	txID, err := types.HexToHash(transfer.TxID)
 	if err != nil {

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -226,15 +226,17 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.setNextExpectedEvent(EventXMRLockedType)
-		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventXMRLockedType: %w", err)
-			return
-		}
-
-		err = s.handleEventKeysReceived(e)
+		err := s.handleEventKeysReceived(e)
 		if err != nil {
 			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
+			if !s.fundsLocked {
+				return
+			}
+		}
+
+		err = s.setNextExpectedEvent(EventXMRLockedType)
+		if err != nil {
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventXMRLockedType: %w", err)
 			return
 		}
 	case *EventXMRLocked:
@@ -246,15 +248,15 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.setNextExpectedEvent(EventETHClaimedType)
+		err := s.handleEventXMRLocked(e)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventETHClaimedType: %w", err)
+			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
 			return
 		}
 
-		err = s.handleEventXMRLocked(e)
+		err = s.setNextExpectedEvent(EventETHClaimedType)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventETHClaimedType: %w", err)
 			return
 		}
 	case *EventETHClaimed:

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -226,15 +226,15 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventKeysReceived(e)
+		err := s.setNextExpectedEvent(EventXMRLockedType)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventXMRLockedType: %w", err)
 			return
 		}
 
-		err = s.setNextExpectedEvent(EventXMRLockedType)
+		err = s.handleEventKeysReceived(e)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventXMRLockedType: %w", err)
+			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
 			return
 		}
 	case *EventXMRLocked:
@@ -246,15 +246,15 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventXMRLocked(e)
+		err := s.setNextExpectedEvent(EventETHClaimedType)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
+			e.errCh <- fmt.Errorf("failed to set next expected event to EventETHClaimedType: %w", err)
 			return
 		}
 
-		err = s.setNextExpectedEvent(EventETHClaimedType)
+		err = s.handleEventXMRLocked(e)
 		if err != nil {
-			e.errCh <- fmt.Errorf("failed to set next expected event to EventETHClaimedType: %w", err)
+			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
 			return
 		}
 	case *EventETHClaimed:

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -77,6 +77,8 @@ type swapState struct {
 
 	// tracks the state of the swap
 	nextExpectedEvent EventType
+	// set to true once funds are locked
+	fundsLocked bool
 
 	// channels
 
@@ -617,6 +619,7 @@ func (s *swapState) lockAsset() (ethcommon.Hash, error) {
 		return ethcommon.Hash{}, fmt.Errorf("timeouts not found in transaction receipt's logs: %w", err)
 	}
 
+	s.fundsLocked = true
 	s.setTimeouts(t0, t1)
 
 	s.contractSwap = &contracts.SwapFactorySwap{


### PR DESCRIPTION
I encountered a bug when testing where if the counterparty exits the swap while the xmrmaker is locking funds, the protocol aborts on the xmrmaker side when it shouldn't (because funds were already locked). This was because the next expected event was being set *after* the handling of the event, so the handling errored and returned, but the next expected event wasn't updated to be `EventContractReady`.

This PR updates the behaviour and fixes that bug. This is also more correct since the stage should definitely be updated once locking occurs.
