### PR TITLE
fix xmrmaker initiation + recovery, don't delete offer from db

### DIFF
--- a/protocol/xmrmaker/net.go
+++ b/protocol/xmrmaker/net.go
@@ -51,8 +51,9 @@ func (inst *Instance) initiate(
 		}
 	}
 
-	// checks passed, delete the offer for now
-	if err = inst.offerManager.DeleteOffer(offer.ID); err != nil {
+	// checks passed, delete the offer from memory for now
+	_, _, err = inst.offerManager.TakeOffer(offer.ID)
+	if err != nil {
 		return nil, err
 	}
 

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -74,9 +74,9 @@ func (m *Manager) GetOffer(id types.Hash) (*types.Offer, *types.OfferExtra, erro
 
 	offer, has := m.offers[id]
 	if !has {
-
 		return nil, nil, errOfferDoesNotExist
 	}
+
 	return offer.offer, offer.extra, nil
 }
 

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -74,6 +74,7 @@ func (m *Manager) GetOffer(id types.Hash) (*types.Offer, *types.OfferExtra, erro
 
 	offer, has := m.offers[id]
 	if !has {
+
 		return nil, nil, errOfferDoesNotExist
 	}
 	return offer.offer, offer.extra, nil

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -114,8 +114,9 @@ func (m *Manager) AddOffer(
 	return extra, nil
 }
 
-// TakeOffer returns any offer with the matching id and removes the offer from the manager. Nil
-// for both values is returned when the passed offer id is not currently managed.
+// TakeOffer returns any offer with the matching id and removes the offer from the cache,
+// but leaves it in the database (unlike the Clear/DeleteOffer methods.)
+// Nil for both values is returned when the passed offer id is not currently managed.
 func (m *Manager) TakeOffer(id types.Hash) (*types.Offer, *types.OfferExtra, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
Previously, xmrmaker recovery of an ongoing swap would fail, because it attempts to get the offer from the db (which it needs), but it was already deleted on swap initiation, causing the daemon to be unable to start up. Now the offer is just deleted from memory (so no one else can take it), but not from the db, so we can still get it on recovery.