### PR TITLE
fixed the TestAbort_ERC20_XMRMakerCancels issue

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -136,8 +136,7 @@ start-daemons() {
 		"--contract-address=${SWAP_FACTORY_ADDR}"
 
 	# Give time for Bob and Charlie's swapd instances to fully start
-	# and do peer discovery.
-	sleep 30
+	sleep 5
 }
 
 stop-daemons() {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -556,6 +556,12 @@ func (s *IntegrationTestSuite) testAbortXMRTakerCancels(asset types.EthAsset) {
 	ac := rpcclient.NewClient(ctx, defaultXMRTakerSwapdEndpoint)
 	awsc := s.newSwapdWSClient(ctx, defaultXMRTakerSwapdWSEndpoint)
 
+	// Bob making an offer above only queues the DHT advertisement for the XMR
+	// namespace (the namespace for swapd hosts providing XMR offers). We need
+	// to wait a little extra before Alice calls Discover to ensure that the
+	// advertisement went out.
+	common.SleepWithContext(ctx, time.Millisecond*500)
+
 	peerIDs, err := ac.Discover(string(coins.ProvidesXMR), defaultDiscoverTimeout)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), 1, len(peerIDs))


### PR DESCRIPTION
Hopefully, the title is true. It does appear to have fixed the issue for me locally.

Closes 332.  To figure out the issue, I added a unit test here:
https://github.com/AthanorLabs/go-p2p-net/pull/2