### PR TITLE
prevent PR gating by codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 # Don't calculate code coverage percentages on generated abigen files
 ignore:
   - ethereum/swap_factory.go


### PR DESCRIPTION
When we switched to `codecov-action@v3` in https://github.com/AthanorLabs/atomic-swap/pull/334, it, inadvertently, enabled PR gating. We may want to enable it at some point, but it will require a more fine-tuned Codecov configuration. These configuration changes should keep the default Codecov commentary, but disable the PR gating.