### PR TITLE
remove `NotifyXMRLocked` message, have xmrtaker check for lock independently

### DIFF
--- a/net/message/message.go
+++ b/net/message/message.go
@@ -22,7 +22,6 @@ const (
 	QueryResponseType byte = iota
 	SendKeysType
 	NotifyETHLockedType
-	NotifyXMRLockType
 )
 
 // TypeToString converts a message type into a string.
@@ -34,8 +33,6 @@ func TypeToString(t byte) string {
 		return "SendKeysMessage"
 	case NotifyETHLockedType:
 		return "NotifyETHLocked"
-	case NotifyXMRLockType:
-		return "NotifyXMRLock"
 	default:
 		return "unknown"
 	}
@@ -59,8 +56,6 @@ func DecodeMessage(b []byte) (common.Message, error) {
 		msg = &SendKeysMessage{}
 	case NotifyETHLockedType:
 		msg = &NotifyETHLocked{}
-	case NotifyXMRLockType:
-		msg = &NotifyXMRLock{}
 	default:
 		return nil, fmt.Errorf("invalid message type=%d", msgType)
 	}
@@ -172,30 +167,4 @@ func (m *NotifyETHLocked) Encode() ([]byte, error) {
 // Type ...
 func (m *NotifyETHLocked) Type() byte {
 	return NotifyETHLockedType
-}
-
-// NotifyXMRLock is sent by XMRMaker to XMRTaker after locking his XMR.
-type NotifyXMRLock struct {
-	Address *mcrypto.Address `json:"address" validate:"required"` // address the monero was sent to
-	TxID    types.Hash       `json:"txID" validate:"required"`    // Monero transaction ID (transaction hash in hex)
-}
-
-// String ...
-func (m *NotifyXMRLock) String() string {
-	return "NotifyXMRLock"
-}
-
-// Encode ...
-func (m *NotifyXMRLock) Encode() ([]byte, error) {
-	b, err := vjson.MarshalStruct(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return append([]byte{NotifyXMRLockType}, b...), nil
-}
-
-// Type ...
-func (m *NotifyXMRLock) Type() byte {
-	return NotifyXMRLockType
 }

--- a/protocol/xmrmaker/event.go
+++ b/protocol/xmrmaker/event.go
@@ -251,12 +251,7 @@ func (s *swapState) handleEvent(event Event) {
 }
 
 func (s *swapState) handleEventETHLocked(e *EventETHLocked) error {
-	resp, err := s.handleNotifyETHLocked(e.message)
-	if err != nil {
-		return err
-	}
-
-	return s.SendSwapMessage(resp, s.ID())
+	return s.handleNotifyETHLocked(e.message)
 }
 
 func (s *swapState) handleEventContractReady() error {

--- a/protocol/xmrmaker/event.go
+++ b/protocol/xmrmaker/event.go
@@ -190,7 +190,7 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventETHLocked(e)
+		err := s.handleNotifyETHLocked(e.message)
 		if err != nil {
 			e.errCh <- fmt.Errorf("failed to handle EventETHLocked: %w", err)
 			if !s.fundsLocked {
@@ -248,10 +248,6 @@ func (s *swapState) handleEvent(event Event) {
 	default:
 		panic("unhandled event type")
 	}
-}
-
-func (s *swapState) handleEventETHLocked(e *EventETHLocked) error {
-	return s.handleNotifyETHLocked(e.message)
 }
 
 func (s *swapState) handleEventContractReady() error {

--- a/protocol/xmrmaker/event_test.go
+++ b/protocol/xmrmaker/event_test.go
@@ -58,7 +58,7 @@ func TestSwapState_handleEvent_EventETHRefunded(t *testing.T) {
 	newSwap(t, s, [32]byte{}, refundKey, desiredAmount.BigInt(), duration)
 
 	// lock XMR
-	_, err = s.lockFunds(coins.MoneroToPiconero(s.info.ProvidedAmount))
+	err = s.lockFunds(coins.MoneroToPiconero(s.info.ProvidedAmount))
 	require.NoError(t, err)
 
 	// call refund w/ XMRTaker's secret

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -146,11 +146,6 @@ func newTestInstanceAndDB(t *testing.T) (*Instance, *offers.MockDatabase) {
 	return inst, db
 }
 
-func newTestInstanceAndNet(t *testing.T) (*Instance, *mockNet) {
-	inst, _, net := newTestInstanceAndDBAndNet(t)
-	return inst, net
-}
-
 func TestInstance_createOngoingSwap(t *testing.T) {
 	inst, offerDB := newTestInstanceAndDB(t)
 	rdb := inst.backend.RecoveryDB().(*backend.MockRecoveryDB)

--- a/protocol/xmrmaker/swap_state_ongoing_test.go
+++ b/protocol/xmrmaker/swap_state_ongoing_test.go
@@ -86,7 +86,7 @@ func TestSwapStateOngoing_Refund(t *testing.T) {
 	newSwap(t, s, [32]byte{}, refundKey, desiredAmount.BigInt(), duration)
 
 	// lock XMR
-	_, err = s.lockFunds(coins.MoneroToPiconero(s.info.ProvidedAmount))
+	err = s.lockFunds(coins.MoneroToPiconero(s.info.ProvidedAmount))
 	require.NoError(t, err)
 	s.cancel()
 

--- a/protocol/xmrtaker/errors.go
+++ b/protocol/xmrtaker/errors.go
@@ -18,7 +18,6 @@ var (
 	errCannotRefund            = errors.New("swap is not at a stage where it can refund")
 	errRefundInvalid           = errors.New("cannot refund, swap does not exist")
 	errRefundSwapCompleted     = fmt.Errorf("cannot refund, %w", errSwapCompleted)
-	errNoLockedXMRAddress      = errors.New("got empty address for locked XMR")
 	errCounterpartyKeysNotSet  = errors.New("counterparty's keys aren't set")
 	errSwapInstantiationNoLogs = errors.New("expected 1 log, got 0")
 	errSwapCompleted           = errors.New("swap is already completed")

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -246,7 +246,7 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventXMRLocked()
+		err := s.handleNotifyXMRLock()
 		if err != nil {
 			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
 			return
@@ -307,10 +307,6 @@ func (s *swapState) handleEventKeysReceived(event *EventKeysReceived) error {
 	}
 
 	return s.SendSwapMessage(resp, s.ID())
-}
-
-func (s *swapState) handleEventXMRLocked() error {
-	return s.handleNotifyXMRLock()
 }
 
 func (s *swapState) handleEventETHClaimed(event *EventETHClaimed) error {

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -131,8 +131,7 @@ func newEventKeysReceived(msg *message.SendKeysMessage) *EventKeysReceived {
 // EventXMRLocked is the second expected event. It represents XMR being locked
 // on-chain.
 type EventXMRLocked struct {
-	message *message.NotifyXMRLock
-	errCh   chan error
+	errCh chan error
 }
 
 // Type ...
@@ -311,7 +310,7 @@ func (s *swapState) handleEventKeysReceived(event *EventKeysReceived) error {
 }
 
 func (s *swapState) handleEventXMRLocked(event *EventXMRLocked) error {
-	return s.handleNotifyXMRLock(event.message)
+	return s.handleNotifyXMRLock()
 }
 
 func (s *swapState) handleEventETHClaimed(event *EventETHClaimed) error {

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -246,7 +246,7 @@ func (s *swapState) handleEvent(event Event) {
 			return
 		}
 
-		err := s.handleEventXMRLocked(e)
+		err := s.handleEventXMRLocked()
 		if err != nil {
 			e.errCh <- fmt.Errorf("failed to handle %s: %w", e.Type(), err)
 			return
@@ -309,7 +309,7 @@ func (s *swapState) handleEventKeysReceived(event *EventKeysReceived) error {
 	return s.SendSwapMessage(resp, s.ID())
 }
 
-func (s *swapState) handleEventXMRLocked(event *EventXMRLocked) error {
+func (s *swapState) handleEventXMRLocked() error {
 	return s.handleNotifyXMRLock()
 }
 

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -140,10 +140,9 @@ func (*EventXMRLocked) Type() EventType {
 	return EventXMRLockedType
 }
 
-func newEventXMRLocked(msg *message.NotifyXMRLock) *EventXMRLocked {
+func newEventXMRLocked() *EventXMRLocked {
 	return &EventXMRLocked{
-		message: msg,
-		errCh:   make(chan error),
+		errCh: make(chan error),
 	}
 }
 

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -50,7 +50,9 @@ func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr *mcrypto.Add
 	require.NoError(t, err)
 
 	// now handle the NotifyXMRLock message
-	err = s.handleNotifyXMRLock()
+	event := newEventXMRLocked()
+	s.eventCh <- event
+	err = <-event.errCh
 	require.NoError(t, err)
 	require.Equal(t, s.nextExpectedEvent, EventETHClaimedType)
 	require.Equal(t, types.ContractReady, s.info.Status)

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -32,15 +32,6 @@ func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr *mcrypto.Add
 	t.Logf("Transferred %d pico XMR (fees %d) to account %s", transfer.Amount, transfer.Fee, xmrAddr)
 	t.Logf("Transfer was mined at block=%d with %d confirmations", transfer.Height, transfer.Confirmations)
 
-	txID, err := types.HexToHash(transfer.TxID)
-	require.NoError(t, err)
-
-	// send notification that monero was locked
-	lmsg := &message.NotifyXMRLock{
-		Address: xmrAddr,
-		TxID:    txID,
-	}
-
 	// assert that ready() is called, setup contract watcher
 	ethHeader, err := backend.ETHClient().Raw().HeaderByNumber(backend.Ctx(), nil)
 	require.NoError(t, err)
@@ -59,7 +50,7 @@ func lockXMRAndCheckForReadyLog(t *testing.T, s *swapState, xmrAddr *mcrypto.Add
 	require.NoError(t, err)
 
 	// now handle the NotifyXMRLock message
-	err = s.HandleProtocolMessage(lmsg)
+	err = s.handleNotifyXMRLock()
 	require.NoError(t, err)
 	require.Equal(t, s.nextExpectedEvent, EventETHClaimedType)
 	require.Equal(t, types.ContractReady, s.info.Status)

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -175,7 +175,7 @@ func (s *swapState) checkForXMRLock() {
 			log.Debugf("checking locked wallet, address=%s balance=%d blocks-to-unlock=%d",
 				lockedAddr, balance.Balance, balance.BlocksToUnlock)
 
-			if s.expectedPiconeroAmount().CmpU64(balance.Balance) <= 0 {
+			if s.expectedPiconeroAmount().CmpU64(balance.UnlockedBalance) <= 0 {
 				event := newEventXMRLocked()
 				s.eventCh <- event
 				err := <-event.errCh

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -144,8 +144,13 @@ func (s *swapState) handleSendKeysMessage(msg *message.SendKeysMessage) (common.
 }
 
 func (s *swapState) checkForXMRLock() {
-	// monero block time is >1 minute, so this should be fine
-	const checkForXMRLockInterval = time.Minute
+	var checkForXMRLockInterval time.Duration
+	if s.Env() == common.Development {
+		checkForXMRLockInterval = time.Second
+	} else {
+		// monero block time is >1 minute, so this should be fine
+		checkForXMRLockInterval = time.Minute
+	}
 
 	// check that XMR was locked in expected account, and confirm amount
 	lockedAddr, vk := s.expectedXMRLockAccount()
@@ -160,7 +165,7 @@ func (s *swapState) checkForXMRLock() {
 
 	log.Debugf("generated view-only wallet to check funds: %s", abViewCli.WalletName())
 
-	timer := time.NewTimer(checkForXMRLockInterval)
+	timer := time.NewTicker(checkForXMRLockInterval)
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
@@ -29,13 +28,6 @@ func (s *swapState) HandleProtocolMessage(msg common.Message) error {
 		if err != nil {
 			return err
 		}
-	// case *message.NotifyXMRLock:
-	// 	event := newEventXMRLocked(msg)
-	// 	s.eventCh <- event
-	// 	err := <-event.errCh
-	// 	if err != nil {
-	// 		return err
-	// 	}
 	default:
 		return errUnexpectedMessageType
 	}
@@ -238,51 +230,7 @@ func (s *swapState) expectedXMRLockAccount() (*mcrypto.Address, *mcrypto.Private
 	return mcrypto.NewPublicKeyPair(sk, vk.Public()).Address(s.Env()), vk
 }
 
-func (s *swapState) handleNotifyXMRLock(msg *message.NotifyXMRLock) error {
-	if msg.Address == nil {
-		return errNoLockedXMRAddress
-	}
-
-	// check that XMR was locked in expected account, and confirm amount
-	lockedAddr, vk := s.expectedXMRLockAccount()
-	if !msg.Address.Equal(lockedAddr) {
-		return fmt.Errorf("address received in message does not match expected address")
-	}
-
-	conf := s.XMRClient().CreateWalletConf("xmrtaker-swap-wallet-verify-funds")
-	abViewCli, err := monero.CreateViewOnlyWalletFromKeys(conf, vk, lockedAddr, s.walletScanHeight)
-	if err != nil {
-		return fmt.Errorf("failed to generate view-only wallet to verify locked XMR: %w", err)
-	}
-	defer abViewCli.CloseAndRemoveWallet()
-
-	log.Debugf("generated view-only wallet to check funds: %s", abViewCli.WalletName())
-
-	balance, err := abViewCli.GetBalance(0)
-	if err != nil {
-		return fmt.Errorf("failed to get balance: %w", err)
-	}
-
-	log.Debugf("checking locked wallet, address=%s balance=%d blocks-to-unlock=%d",
-		lockedAddr, balance.Balance, balance.BlocksToUnlock)
-
-	if s.expectedPiconeroAmount().CmpU64(balance.Balance) > 0 {
-		return fmt.Errorf("locked XMR amount is less than expected: got %s, expected %s",
-			coins.FmtPiconeroAmtAsXMR(balance.Balance), s.ExpectedAmount().Text('f'))
-	}
-
-	// Monero received from a transfer is locked for a minimum of 10 confirmations before
-	// it can be spent again. The maker is required to wait for 10 confirmations before
-	// notifying us that the XMR is locked and should not be adding additional wait
-	// requirements. We give one block of leniency, in case the taker's node is not fully
-	// synced. Our goal is to prevent double spends, issues due to block reorgs, and
-	// prevent the maker from locking our funds until close to the heat death of the
-	// universe (https://github.com/monero-project/research-lab/issues/78).
-	if balance.BlocksToUnlock > 1 {
-		return fmt.Errorf("received XMR funds are not unlocked as required (blocks-to-unlock=%d)",
-			balance.BlocksToUnlock)
-	}
-
+func (s *swapState) handleNotifyXMRLock() error {
 	close(s.xmrLockedCh)
 	log.Info("XMR was locked successfully, setting contract to ready...")
 

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -189,6 +189,10 @@ func newSwapStateFromOngoing(
 	s.contractSwap = ethSwapInfo.Swap
 	s.xmrmakerPublicSpendKey = makerSk
 	s.xmrmakerPrivateViewKey = makerVk
+
+	if info.Status == types.ETHLocked {
+		go s.checkForXMRLock()
+	}
 	return s, nil
 }
 

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -239,15 +239,10 @@ func lockXMRFunds(
 	wc monero.WalletClient,
 	destAddr *mcrypto.Address,
 	amount *coins.PiconeroAmount,
-) types.Hash {
+) {
 	monero.MineMinXMRBalance(t, wc, amount)
-	transfer, err := wc.Transfer(ctx, destAddr, 0, amount, monero.MinSpendConfirmations)
+	_, err := wc.Transfer(ctx, destAddr, 0, amount, monero.MinSpendConfirmations)
 	require.NoError(t, err)
-
-	txID, err := types.HexToHash(transfer.TxID)
-	require.NoError(t, err)
-
-	return txID
 }
 
 func TestSwapState_NotifyXMRLock(t *testing.T) {
@@ -271,12 +266,8 @@ func TestSwapState_NotifyXMRLock(t *testing.T) {
 	kp := mcrypto.SumSpendAndViewKeys(xmrmakerKeysAndProof.PublicKeyPair, s.pubkeys)
 	xmrAddr := kp.Address(common.Development)
 
-	msg := &message.NotifyXMRLock{
-		Address: xmrAddr,
-		TxID:    lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount()),
-	}
-
-	err = s.HandleProtocolMessage(msg)
+	lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount())
+	err = s.handleNotifyXMRLock()
 	require.NoError(t, err)
 	require.Equal(t, EventETHClaimedType, s.nextExpectedEvent)
 }
@@ -305,12 +296,8 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 	kp := mcrypto.SumSpendAndViewKeys(xmrmakerKeysAndProof.PublicKeyPair, s.pubkeys)
 	xmrAddr := kp.Address(common.Development)
 
-	msg := &message.NotifyXMRLock{
-		Address: xmrAddr,
-		TxID:    lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount()),
-	}
-
-	err = s.HandleProtocolMessage(msg)
+	lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount())
+	err = s.handleNotifyXMRLock()
 	require.NoError(t, err)
 	require.Equal(t, EventETHClaimedType, s.nextExpectedEvent)
 

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -267,7 +267,9 @@ func TestSwapState_NotifyXMRLock(t *testing.T) {
 	xmrAddr := kp.Address(common.Development)
 
 	lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount())
-	err = s.handleNotifyXMRLock()
+	event := newEventXMRLocked()
+	s.eventCh <- event
+	err = <-event.errCh
 	require.NoError(t, err)
 	require.Equal(t, EventETHClaimedType, s.nextExpectedEvent)
 }
@@ -297,7 +299,9 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 	xmrAddr := kp.Address(common.Development)
 
 	lockXMRFunds(t, s.ctx, s.XMRClient(), xmrAddr, s.expectedPiconeroAmount())
-	err = s.handleNotifyXMRLock()
+	event := newEventXMRLocked()
+	s.eventCh <- event
+	err = <-event.errCh
 	require.NoError(t, err)
 	require.Equal(t, EventETHClaimedType, s.nextExpectedEvent)
 


### PR DESCRIPTION
as title says, we don't need to worry about the balance unlock time anymore either, as the xmrtaker only notifies itself of the event `EventXMRLocked` once the unlocked balance is >= the expected amount to receive.

closes #335