### PR TITLE
update `swap_getPast` to match `swap_getOngoing`; update docs

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -703,10 +703,11 @@ func runGetPastSwap(ctx *cli.Context) error {
 			endTime = info.EndTime.Format(common.TimeFmtSecs)
 		}
 
+		fmt.Printf("ID: %s\n", info.ID)
 		fmt.Printf("Start time: %s\n", info.StartTime.Format(common.TimeFmtSecs))
 		fmt.Printf("End time: %s\n", endTime)
 		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), info.Provided)
-		fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount.Text('f'), receivedCoin)
+		fmt.Printf("Received: %s %s\n", info.ExpectedAmount.Text('f'), receivedCoin)
 		fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
 		fmt.Printf("Status: %s\n", info.Status)
 	}

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -634,9 +634,14 @@ func runTake(ctx *cli.Context) error {
 }
 
 func runGetOngoingSwap(ctx *cli.Context) error {
-	offerID, err := types.HexToHash(ctx.String(flagOfferID))
-	if err != nil {
-		return errInvalidFlagValue(flagOfferID, err)
+	var offerID *types.Hash
+
+	if ctx.IsSet(flagOfferID) {
+		hash, err := types.HexToHash(ctx.String(flagOfferID))
+		if err != nil {
+			return errInvalidFlagValue(flagOfferID, err)
+		}
+		offerID = &hash
 	}
 
 	c := newRRPClient(ctx)
@@ -677,9 +682,14 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 }
 
 func runGetPastSwap(ctx *cli.Context) error {
-	offerID, err := types.HexToHash(ctx.String(flagOfferID))
-	if err != nil {
-		return errInvalidFlagValue(flagOfferID, err)
+	var offerID *types.Hash
+
+	if ctx.IsSet(flagOfferID) {
+		hash, err := types.HexToHash(ctx.String(flagOfferID))
+		if err != nil {
+			return errInvalidFlagValue(flagOfferID, err)
+		}
+		offerID = &hash
 	}
 
 	c := newRRPClient(ctx)

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -634,7 +634,10 @@ func runTake(ctx *cli.Context) error {
 }
 
 func runGetOngoingSwap(ctx *cli.Context) error {
-	offerID := ctx.String(flagOfferID)
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
 
 	c := newRRPClient(ctx)
 	resp, err := c.GetOngoingSwap(offerID)
@@ -674,7 +677,10 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 }
 
 func runGetPastSwap(ctx *cli.Context) error {
-	offerID := ctx.String(flagOfferID)
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
 
 	c := newRRPClient(ctx)
 	resp, err := c.GetPastSwap(offerID)
@@ -716,7 +722,10 @@ func runGetPastSwap(ctx *cli.Context) error {
 }
 
 func runRefund(ctx *cli.Context) error {
-	offerID := ctx.String(flagOfferID)
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
 
 	c := newRRPClient(ctx)
 	resp, err := c.Refund(offerID)

--- a/common/types/hash.go
+++ b/common/types/hash.go
@@ -22,10 +22,15 @@ func IsHashZero(h Hash) bool {
 
 // HexToHash decodes a hex-encoded string into a hash
 func HexToHash(s string) (Hash, error) {
+	if s == "" {
+		return EmptyHash, nil
+	}
+
 	h, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
 	if err != nil {
 		return Hash{}, err
 	}
+
 	if len(h) != len(Hash{}) {
 		return Hash{}, fmt.Errorf("invalid len=%d hash", len(h))
 	}

--- a/docs/local.md
+++ b/docs/local.md
@@ -212,10 +212,12 @@ the swap protocol.
 
 To query the information for an ongoing swap, you can run:
 ```bash
-./bin/swapcli get-ongoing-swap --offer-id <id>
+./bin/swapcli ongoing --offer-id <id>
 ```
 
 To query information for a past swap using its ID, you can run:
 ```bash
-./bin/swapcli get-past-swap --offer-id <id>
+./bin/swapcli past --offer-id <id>
 ```
+
+For both of these commands, if no `--offer-id` is passed, all ongoing or past swaps will be returned.

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -382,7 +382,7 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 
 ### `swap_getOngoing`
 
-Gets information for the specified ongoing swap.
+Gets information for ongoing swaps. If no ID is provided, all ongoing swaps are returned. Otherwise, only the swap with the specified ID is returned.
 
 Parameters:
 - `offerID`: (optional) the swap's ID.
@@ -392,12 +392,14 @@ Returns:
 
 Each items in `swaps` contains:
 - `id`: the swap ID.
-- `startTime`: the start time of the swap (in RFC 3339 format).
 - `provided`: the coin provided during the swap.
 - `providedAmount`: the amount of coin provided during the swap.
 - `receivedAmount`: the amount of coin expected to be received during the swap.
 - `exchangeRate`: the exchange rate of the swap, expressed in a ratio of XMR/ETH.
-- `status`: the swap's status; should always be "ongoing".
+- `status`: the swap's status.
+- `startTime`: the start time of the swap (in RFC 3339 format).
+- `timeout0`: the time at which the ETH-taker can always claim ETH, and the ETH-maker can no longer refund.
+- `timeout1`: the time at which the ETH-taker can no longer claim ETH, and the ETH-maker is able to refund.
 
 Example:
 ```bash
@@ -411,13 +413,15 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
   "result": {
     "swaps": [
       {
-        "id": "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381",
+        "id": "0xb12d3ecf4d437cfe682e6d455e4a9b2432e730e51029f2551e923b9695f36063",
         "provided": "ETH",
-        "providedAmount": "0.18",
-        "expectedAmount": "0.18",
-        "exchangeRate": "1",
+        "providedAmount": "0.006",
+        "expectedAmount": "0.12",
+        "exchangeRate": "0.05",
         "status": "ETHLocked",
-        "startTime": "2023-02-20T23:52:28.826764666Z"
+        "startTime": "2023-03-18T16:47:50.598029743-04:00",
+        "timeout0": "2023-03-18T16:49:55-04:00",
+        "timeout1": "2023-03-18T16:51:55-04:00"
       }
     ]
   },
@@ -436,63 +440,26 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
   "result": {
     "swaps": [
       {
-        "id": "0xea9e976d11871627c8fed3f15e0ec3857364d61c632cbf9f1da4dca603397c4f",
+        "id": "0x4e3c5db727b312ff7eefa6d6e18ac44285e20b75e5255c16255a9b741bc311d3",
         "provided": "ETH",
-        "providedAmount": "0.14",
-        "expectedAmount": "0.14",
+        "providedAmount": "0.1",
+        "expectedAmount": "0.1",
         "exchangeRate": "1",
         "status": "ETHLocked",
-        "startTime": "2023-02-20T22:01:24.145265256Z"
+        "startTime": "2023-03-18T16:52:56.304958446-04:00",
+        "timeout0": "2023-03-18T16:55:01-04:00",
+        "timeout1": "2023-03-18T16:57:01-04:00"
       },
       {
-        "id": "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381",
+        "id": "0x8f23b7e187b1db26fcfd23c1699c3e56221153fd7225ada0b0cae8fdbd1cab65",
         "provided": "ETH",
-        "providedAmount": "0.18",
-        "expectedAmount": "0.18",
+        "providedAmount": "0.1",
+        "expectedAmount": "0.1",
         "exchangeRate": "1",
         "status": "ETHLocked",
-        "startTime": "2023-02-20T23:52:28.826764666Z"
-      }
-    ]
-  },
-  "id": "0"
-}
-```
-
-### `swap_getPastIDs`
-
-Gets all past swap IDs.
-
-Parameters:
-- none
-
-Returns:
-- `ids`: a list of all past swap IDs.
-
-Each item in `ids` contains:
-- `id`: the ID of the swap.
-- `startTime`: the start time of the swap (in RFC 3339 format).
-- `endTime`: the end time of the swap (in RFC 3339 format).
-
-Example:
-```bash
-curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
-'{"jsonrpc":"2.0","id":"0","method":"swap_getPastIDs","params":{}}' | jq
-```
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "ids": [
-      {
-        "id": "0x25d567ce6d963750e17946905bb334580b9e469c8f23e724ab98df535277dcc2",
-        "startTime": "2023-02-20T21:56:44.006075694Z",
-        "endTime": "2023-02-20T21:56:47.023332658Z"
-      },
-      {
-        "id": "0x38083ead32b9278c71ec6225b11d12aa6aaa677992afe415f26b4648572b4206",
-        "startTime": "2023-02-20T21:14:02.04949932Z",
-        "endTime": "2023-02-20T21:36:21.362943839Z"
+        "startTime": "2023-03-18T16:53:02.642556563-04:00",
+        "timeout0": "2023-03-18T16:55:07-04:00",
+        "timeout1": "2023-03-18T16:57:07-04:00"
       }
     ]
   },
@@ -502,34 +469,47 @@ curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 
 ### `swap_getPast`
 
-Gets a past swap information for the given swap ID.
+Gets information for past swaps. If no ID is provided, all past swaps are returned. Otherwise, only the swap with the specified ID is returned.
 
-Paramters:
-- `offerID`: the swap ID.
+Parameters:
+- `offerID`: (optional) the swap's ID.
 
 Returns:
+- `swaps`: a list of past swaps. If an offerID is provided, this returns only the swap with that ID, if it exists.
+
+Each items in `swaps` contains:
+- `id`: the swap ID.
 - `provided`: the coin provided during the swap.
 - `providedAmount`: the amount of coin provided during the swap.
-- `receivedAmount`: the amount of coin received during the swap.
+- `receivedAmount`: the amount of coin expected to be received during the swap.
 - `exchangeRate`: the exchange rate of the swap, expressed in a ratio of XMR/ETH.
-- `status`: the swap's status, one of `success`, `refunded`, or `aborted`.
+- `status`: the swap's exit status.
+- `startTime`: the start time of the swap (in RFC 3339 format).
+- `end`: the end time of the swap (in RFC 3339 format).
 
 Example:
 ```bash
 curl -s -X POST http://127.0.0.1:5000 -H 'Content-Type: application/json' -d \
 '{"jsonrpc":"2.0","id":"0","method":"swap_getPast",
-"params":{"offerID": "0xa7429fdb7ce0c0b19bd2450cb6f8274aa9d86b3e5f9386279e95671c24fd8381"}}' \
+"params":{"offerID": "0xb12d3ecf4d437cfe682e6d455e4a9b2432e730e51029f2551e923b9695f36063"}}' \
 | jq
 ```
 ```json
 {
   "jsonrpc": "2.0",
   "result": {
-    "provided": "ETH",
-    "providedAmount": "0.01",
-    "receivedAmount": "1",
-    "exchangeRate": "0.01",
-    "status": "Success"
+    "swaps": [
+      {
+        "id": "0xb12d3ecf4d437cfe682e6d455e4a9b2432e730e51029f2551e923b9695f36063",
+        "provided": "ETH",
+        "providedAmount": "0.006",
+        "expectedAmount": "0.12",
+        "exchangeRate": "0.05",
+        "status": "Success",
+        "startTime": "2023-03-18T16:47:50.598029743-04:00",
+        "endTime": "2023-03-18T16:48:14.942103399-04:00"
+      }
+    ]
   },
   "id": "0"
 }

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -65,7 +65,7 @@ type GetPastRequest struct {
 
 // GetPastResponse ...
 type GetPastResponse struct {
-	Swaps []*PastSwap `json:"swaps" validate:"required"`
+	Swaps []*PastSwap `json:"swaps" validate:"dive,required"`
 }
 
 // GetPast returns information about a past swap given its ID.
@@ -131,14 +131,14 @@ type OngoingSwap struct {
 	Timeout1       *time.Time          `json:"timeout1"`
 }
 
-// GetOngoingResponse ...
-type GetOngoingResponse struct {
-	Swaps []*OngoingSwap `json:"swaps" validate:"dive,required"`
-}
-
 // GetOngoingRequest ...
 type GetOngoingRequest struct {
 	OfferID types.Hash `json:"offerID" validate:"required"`
+}
+
+// GetOngoingResponse ...
+type GetOngoingResponse struct {
+	Swaps []*OngoingSwap `json:"swaps" validate:"dive,required"`
 }
 
 // GetOngoing returns information about the ongoing swap with the given ID, if there is one.

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -60,7 +60,7 @@ type PastSwap struct {
 
 // GetPastRequest ...
 type GetPastRequest struct {
-	OfferID types.Hash `json:"offerID"`
+	OfferID *types.Hash `json:"offerID,omitempty"`
 }
 
 // GetPastResponse ...
@@ -74,7 +74,7 @@ type GetPastResponse struct {
 func (s *SwapService) GetPast(_ *http.Request, req *GetPastRequest, resp *GetPastResponse) error {
 	var swaps []*swap.Info
 
-	if types.IsHashZero(req.OfferID) {
+	if req.OfferID == nil {
 		ids, err := s.sm.GetPastIDs()
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func (s *SwapService) GetPast(_ *http.Request, req *GetPastRequest, resp *GetPas
 			swaps = append(swaps, info)
 		}
 	} else {
-		info, err := s.sm.GetPastSwap(req.OfferID)
+		info, err := s.sm.GetPastSwap(*req.OfferID)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ type OngoingSwap struct {
 
 // GetOngoingRequest ...
 type GetOngoingRequest struct {
-	OfferID types.Hash `json:"offerID" validate:"required"`
+	OfferID *types.Hash `json:"offerID,omitempty"`
 }
 
 // GetOngoingResponse ...
@@ -148,13 +148,13 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 		err   error
 	)
 
-	if types.IsHashZero(req.OfferID) {
+	if req.OfferID == nil {
 		swaps, err = s.sm.GetOngoingSwaps()
 		if err != nil {
 			return err
 		}
 	} else {
-		info, err := s.sm.GetOngoingSwap(req.OfferID)
+		info, err := s.sm.GetOngoingSwap(*req.OfferID)
 		if err != nil {
 			return err
 		}

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -7,21 +7,6 @@ import (
 	"github.com/athanorlabs/atomic-swap/rpc"
 )
 
-// GetPastSwapIDs calls swap_getPastIDs
-func (c *Client) GetPastSwapIDs() ([]*rpc.PastSwapInfo, error) {
-	const (
-		method = "swap_getPastIDs"
-	)
-
-	res := &rpc.GetPastIDsResponse{}
-
-	if err := c.Post(method, nil, res); err != nil {
-		return nil, err
-	}
-
-	return res.Swaps, nil
-}
-
 // GetOngoingSwap calls swap_getOngoing
 func (c *Client) GetOngoingSwap(id string) (*rpc.GetOngoingResponse, error) {
 	const (

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetOngoingSwap calls swap_getOngoing
-func (c *Client) GetOngoingSwap(id types.Hash) (*rpc.GetOngoingResponse, error) {
+func (c *Client) GetOngoingSwap(id *types.Hash) (*rpc.GetOngoingResponse, error) {
 	const (
 		method = "swap_getOngoing"
 	)
@@ -26,7 +26,7 @@ func (c *Client) GetOngoingSwap(id types.Hash) (*rpc.GetOngoingResponse, error) 
 }
 
 // GetPastSwap calls swap_getPast
-func (c *Client) GetPastSwap(id types.Hash) (*rpc.GetPastResponse, error) {
+func (c *Client) GetPastSwap(id *types.Hash) (*rpc.GetPastResponse, error) {
 	const (
 		method = "swap_getPast"
 	)

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetOngoingSwap calls swap_getOngoing
-func (c *Client) GetOngoingSwap(id string) (*rpc.GetOngoingResponse, error) {
+func (c *Client) GetOngoingSwap(id types.Hash) (*rpc.GetOngoingResponse, error) {
 	const (
 		method = "swap_getOngoing"
 	)
@@ -26,7 +26,7 @@ func (c *Client) GetOngoingSwap(id string) (*rpc.GetOngoingResponse, error) {
 }
 
 // GetPastSwap calls swap_getPast
-func (c *Client) GetPastSwap(id string) (*rpc.GetPastResponse, error) {
+func (c *Client) GetPastSwap(id types.Hash) (*rpc.GetPastResponse, error) {
 	const (
 		method = "swap_getPast"
 	)
@@ -45,7 +45,7 @@ func (c *Client) GetPastSwap(id string) (*rpc.GetPastResponse, error) {
 }
 
 // Refund calls swap_refund
-func (c *Client) Refund(id string) (*rpc.RefundResponse, error) {
+func (c *Client) Refund(id types.Hash) (*rpc.RefundResponse, error) {
 	const (
 		method = "swap_refund"
 	)


### PR DESCRIPTION
- update `swap_getPast` to match `swap_getOngoing`'s behaviour; returns all past swaps if no ID is provided
- remove `swap_getPastIDs`
- update `swapcli get-past-swaps` -> `swapcli past` and `swapcli get-ongoing-swaps` -> `swapcli ongoing` (I think this is clearer and less to type out)
- update docs

closes #349