### PR TITLE
move stagenet from goerli to sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Please see the [protocol documentation](docs/protocol.md) for how it works.
 
 To try the swap locally with two nodes (maker and taker) on a development environment, follow the instructions [here](./docs/local.md).
 
-### Trying it on Monero's stagenet and Ethereum's Goerli testnet
+### Trying it on Monero's stagenet and Ethereum's Sepolia testnet
 
-To try the swap on Stagenet/Goerli, follow the instructions [here](./docs/stagenet.md).
+To try the swap on Stagenet/Sepolia, follow the instructions [here](./docs/stagenet.md).
 
 ## Additional documentation
 

--- a/cliutil/utils.go
+++ b/cliutil/utils.go
@@ -75,7 +75,15 @@ func GetEthereumPrivateKey(ethPrivKeyFile string, env common.Environment, devXMR
 		return nil, fmt.Errorf("failed to read ethereum-privkey file: %w", err)
 	}
 	ethPrivKeyHex := strings.TrimSpace(string(fileData))
-	return ethcrypto.HexToECDSA(ethPrivKeyHex)
+	privkey, err := ethcrypto.HexToECDSA(ethPrivKeyHex)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Using ETH wallet key located in %s", ethPrivKeyFile)
+	log.Infof("ETH address:",
+		ethcrypto.PubkeyToAddress(*(key.Public().(*ecdsa.PublicKey))).Hex())
+	return privkey, nil
 }
 
 // GetVersion returns our version string for an executable

--- a/cliutil/utils.go
+++ b/cliutil/utils.go
@@ -83,7 +83,7 @@ func GetEthereumPrivateKey(ethPrivKeyFile string, env common.Environment, devXMR
 
 	if exists {
 		log.Infof("Using ETH wallet key located in %s", ethPrivKeyFile)
-		log.Infof("ETH address:", ethcrypto.PubkeyToAddress(*(privkey.Public().(*ecdsa.PublicKey))).Hex())
+		log.Infof("ETH address: %s", ethcrypto.PubkeyToAddress(*(privkey.Public().(*ecdsa.PublicKey))).Hex())
 	}
 
 	return privkey, nil

--- a/cliutil/utils.go
+++ b/cliutil/utils.go
@@ -54,12 +54,13 @@ func createAndWriteEthKeyFile(ethPrivKeyFile string, env common.Environment, dev
 
 // GetEthereumPrivateKey reads or creates and returns an ethereum private key for the given the CLI options.
 func GetEthereumPrivateKey(ethPrivKeyFile string, env common.Environment, devXMRMaker, devXMRTaker bool) (
-	key *ecdsa.PrivateKey,
-	err error,
+	*ecdsa.PrivateKey,
+	error,
 ) {
 	if ethPrivKeyFile == "" {
 		panic("missing required parameter ethPrivKeyFile")
 	}
+
 	exists, err := common.FileExists(ethPrivKeyFile)
 	if err != nil {
 		return nil, err
@@ -80,9 +81,11 @@ func GetEthereumPrivateKey(ethPrivKeyFile string, env common.Environment, devXMR
 		return nil, err
 	}
 
-	log.Infof("Using ETH wallet key located in %s", ethPrivKeyFile)
-	log.Infof("ETH address:",
-		ethcrypto.PubkeyToAddress(*(key.Public().(*ecdsa.PublicKey))).Hex())
+	if exists {
+		log.Infof("Using ETH wallet key located in %s", ethPrivKeyFile)
+		log.Infof("ETH address:", ethcrypto.PubkeyToAddress(*(privkey.Public().(*ecdsa.PublicKey))).Hex())
+	}
+
 	return privkey, nil
 }
 

--- a/common/config.go
+++ b/common/config.go
@@ -64,7 +64,7 @@ func MainnetConfig() *Config {
 	}
 }
 
-// StagenetConfig is the monero stagenet and ethereum Gorli configuration
+// StagenetConfig is the monero stagenet and ethereum Sepolia configuration
 func StagenetConfig() *Config {
 	return &Config{
 		Env:     Stagenet,
@@ -83,8 +83,8 @@ func StagenetConfig() *Config {
 				Port: 38081,
 			},
 		},
-		SwapFactoryAddress:       ethcommon.HexToAddress("0x3d561C6f938aDBc45239772cc6A39e1Db7192154"),
-		ForwarderContractAddress: ethcommon.HexToAddress("0x4a707181842Ef084daFC90DeF367a1825eCcBCab"),
+		SwapFactoryAddress:       ethcommon.HexToAddress("0xE5656d3549478BdE248e5D7aE22ff8DCC5Cd11a3"),
+		ForwarderContractAddress: ethcommon.HexToAddress("0x171f294A0Ca7085Ce5F73DE1BE28b9721e007B94"),
 		Bootnodes: []string{
 			"/ip4/134.122.115.208/tcp/9900/p2p/12D3KooWDqCzbjexHEa8Rut7bzxHFpRMZyDRW1L6TGkL1KY24JH5",
 			"/ip4/143.198.123.27/tcp/9900/p2p/12D3KooWSc4yFkPWBFmPToTMbhChH3FAgGH96DNzSg5fio1pQYoN",

--- a/common/consts.go
+++ b/common/consts.go
@@ -32,7 +32,7 @@ const (
 // Ethereum chain IDs
 const (
 	MainnetChainID = 1
-	GoerliChainID  = 5
+	SepoliaChainID = 11155111
 	GanacheChainID = 1337
 	HardhatChainID = 31337
 )

--- a/common/network_test.go
+++ b/common/network_test.go
@@ -23,6 +23,6 @@ func TestNewEnv(t *testing.T) {
 }
 
 func TestNewEnv_fail(t *testing.T) {
-	_, err := NewEnv("goerli")
+	_, err := NewEnv("something")
 	require.ErrorContains(t, err, "unknown")
 }

--- a/docs/stagenet.md
+++ b/docs/stagenet.md
@@ -40,6 +40,7 @@ For Linux 64-bit, you can do:
 
 6. Fund your Sepolia account using a faucet: 
 - https://sepolia-faucet.pk910.de/
+- https://sepoliafaucet.com/
 - https://sepolia.dev/
 
 7. Obtain a Sepolia JSON-RPC endpoint. If you don't want to sync your own node, you can find public ones here: https://sepolia.dev/

--- a/docs/stagenet.md
+++ b/docs/stagenet.md
@@ -1,6 +1,6 @@
-# Joining the Stagenet/Goerli network
+# Joining the Stagenet/Sepolia network
 
-Currently, an initial version of the swap is deployed onto the Goerli (Ethereum testnet) and Monero Stagenet networks. To join the network and try out the swap, either as a maker or a taker, please see the following.
+Currently, an initial version of the swap is deployed onto the Sepolia (Ethereum testnet) and Monero Stagenet networks. To join the network and try out the swap, either as a maker or a taker, please see the following.
 
 > Note: a swap on stagenet currently takes around 10-20 minutes due to block times.
 
@@ -9,7 +9,7 @@ Currently, an initial version of the swap is deployed onto the Goerli (Ethereum 
 ## Setup 
 
 The atomic swap daemon requires access to a fully synced, stagenet monerod daemon,
-a Goerli network endpoint, and a Goerli network private key funded with some GoETH.
+a Sepolia network endpoint, and a Sepolia network private key funded with some SepETH.
 
 1. Install the Monero CLI if you haven't already. You can get it [here](https://www.getmonero.org/downloads/#cli):
 
@@ -31,21 +31,18 @@ For Linux 64-bit, you can do:
    data. If you skip this step, a new wallet will be created that you can later fund for
    swaps.
 
-4. Create a Goerli wallet. You can do this using Metamask by selecting "Goerli Test Network" from the networks, then creating a new account with "Create account". I'd recommend naming this new account something explicit like `goerli-swap-account`.
+4. Create a Sepolia wallet. You can do this using Metamask by selecting "Sepolia Test Network" from the networks, then creating a new account with "Create account". I'd recommend naming this new account something explicit like `sepolia-swap-account`.
 
 5. Optional: Export the private key for this account by navigating to: three dots in upper right of
    Metamask -> account details -> export private key. Paste this private key into a file
-   named `{DATA_DIR}/eth.key`. If you skip this step, a new goerli wallet will be created for you
-   that you can transfer Goerli ether to or fund directly in the next step.
+   named `{DATA_DIR}/eth.key`. If you skip this step, a new wallet will be created for you
+   that you can transfer Sepolia ether to or fund directly in the next step.
 
-6. Fund your Goerli account using a faucet: 
-- https://goerli-faucet.pk910.de/
-- https://goerlifaucet.com/
-- https://goerli-faucet.mudit.blog/
+6. Fund your Sepolia account using a faucet: 
+- https://sepolia-faucet.pk910.de/
+- https://sepolia.dev/
 
-If you don't have any luck with these, please message me on twitter/reddit (@elizabethereum) with your Goerli address, and I can send you some GoETH.
-
-7. Obtain a Goerli JSON-RPC endpoint. You can get one from infura.io, or you can sync your own node, or ask a friend for their endpoint. 
+7. Obtain a Sepolia JSON-RPC endpoint. If you don't want to sync your own node, you can find public ones here: https://sepolia.dev/
 
 8. Install go 1.19+. See [build instructions](./build.md) for more details.
 
@@ -56,11 +53,9 @@ cd atomic-swap
 make build
 ```
 
-10. Start the `swapd` daemon. If you are using an Infura Goerli endpoint,
-    copy-paste your API key into the field below following the `--ethereum-endpoint` flag.
-    Otherwise, change `--ethereum-endpoint` to point to your endpoint.
+10. Start the `swapd` daemon. Change `--ethereum-endpoint` to point to your endpoint.
 ```bash
-./swapd --env stagenet --ethereum-endpoint=https://goerli.infura.io/v3/<your-api-key>
+./swapd --env stagenet --ethereum-endpoint=<sepolia-endpoint>
 ```
 Note: You probably need additional flags above:
 * `--data-dir PATH`: Needed if you are launching more than one `swapd` instance
@@ -160,7 +155,7 @@ If you don't have any luck with these, please message me on twitter/reddit (@eli
 
 > Note: the exchange rate is the ratio of XMR:ETH price. So for example, a ratio of 0.05 would mean 20 XMR to 1 ETH. Since we're on testnet, it's not critical what you set it to. 
 
-When a peer takes your offer, you will see logs in `swapd` notifying you that a swap has been initiated. If all goes well, you should receive the GoETH in the Goerli account created earlier.
+When a peer takes your offer, you will see logs in `swapd` notifying you that a swap has been initiated. If all goes well, you should receive the SepETH in the Sepolia account created earlier.
 
 > Note: if you exit the `swapd` process, your offers are currently not saved, so when you restart you will not have any offers.
 

--- a/ethereum/check_swap_factory_contract_test.go
+++ b/ethereum/check_swap_factory_contract_test.go
@@ -119,29 +119,29 @@ func TestCheckSwapFactoryContractCode_fail(t *testing.T) {
 	require.ErrorIs(t, err, errInvalidSwapContract)
 }
 
-func TestGoerliContract(t *testing.T) {
-	// comment out the next line to test the default goerli contract
-	t.Skip("requires access to non-vetted external goerli node")
-	const goerliEndpoint = "https://ethereum-goerli-rpc.allthatnode.com"
-	// temporarily place a funded goerli private key below to deploy the test contract
-	const goerliKey = ""
+func TestSepoliaContract(t *testing.T) {
+	// comment out the next line to test the default sepolia contract
+	t.Skip("requires access to non-vetted external sepolia node")
+	const sepoliaEndpoint = "https://rpc.sepolia.org/"
+	// temporarily place a funded sepolia private key below to deploy the test contract
+	const sepoliaKey = ""
 
 	ctx := context.Background()
-	ec, err := ethclient.Dial(goerliEndpoint)
+	ec, err := ethclient.Dial(sepoliaEndpoint)
 	require.NoError(t, err)
 	defer ec.Close()
 
 	parsedTFAddr, err := CheckSwapFactoryContractCode(ctx, ec, common.StagenetConfig().SwapFactoryAddress)
-	if errors.Is(err, errInvalidSwapContract) && goerliKey != "" {
-		pk, err := ethcrypto.HexToECDSA(goerliKey) //nolint:govet // shadow declaration of err
+	if errors.Is(err, errInvalidSwapContract) && sepoliaKey != "" {
+		pk, err := ethcrypto.HexToECDSA(sepoliaKey) //nolint:govet // shadow declaration of err
 		require.NoError(t, err)
 		forwarderAddr := deployForwarder(t, ec, pk)
 		sfAddr, _, err := DeploySwapFactoryWithKey(context.Background(), ec, pk, forwarderAddr)
 		require.NoError(t, err)
-		t.Logf("New Goerli SwapFactory deployed with TrustedForwarder=%s", forwarderAddr)
+		t.Logf("New Sepolia SwapFactory deployed with TrustedForwarder=%s", forwarderAddr)
 		t.Fatalf("Update common.StagenetConfig.ContractAddress with %s", sfAddr.Hex())
 	} else {
 		require.NoError(t, err)
-		t.Logf("Goerli SwapFactory deployed with TrustedForwarder=%s", parsedTFAddr.Hex())
+		t.Logf("Sepolia SwapFactory deployed with TrustedForwarder=%s", parsedTFAddr.Hex())
 	}
 }

--- a/ethereum/extethclient/eth_wallet_client.go
+++ b/ethereum/extethclient/eth_wallet_client.go
@@ -267,8 +267,8 @@ func validateChainID(env common.Environment, chainID *big.Int) error {
 			return fmt.Errorf("expected Mainnet chain ID (%d), but found %s", common.MainnetChainID, chainID)
 		}
 	case common.Stagenet:
-		if chainID.Cmp(big.NewInt(common.GoerliChainID)) != 0 {
-			return fmt.Errorf("expected Goerli chain ID (%d), but found %s", common.GoerliChainID, chainID)
+		if chainID.Cmp(big.NewInt(common.SepoliaChainID)) != 0 {
+			return fmt.Errorf("expected Sepolia chain ID (%d), but found %s", common.SepoliaChainID, chainID)
 		}
 	case common.Development:
 		if chainID.Cmp(big.NewInt(common.GanacheChainID)) != 0 {

--- a/ethereum/extethclient/eth_wallet_client_test.go
+++ b/ethereum/extethclient/eth_wallet_client_test.go
@@ -22,5 +22,5 @@ func Test_validateChainID_mismatchedEnv(t *testing.T) {
 
 	err = validateChainID(common.Stagenet, big.NewInt(common.GanacheChainID))
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "expected Goerli chain ID (5), but found 1337")
+	assert.ErrorContains(t, err, "expected Sepolia chain ID (11155111), but found 1337")
 }

--- a/pricefeed/pricefeed.go
+++ b/pricefeed/pricefeed.go
@@ -54,8 +54,8 @@ func GetETHUSDPrice(ctx context.Context, ec *ethclient.Client) (*PriceFeed, erro
 	switch chainID.Uint64() {
 	case common.MainnetChainID:
 		// No extra work to do
-	case common.GoerliChainID:
-		// Push stagenet/goerli users to a mainnet endpoint
+	case common.SepoliaChainID:
+		// Push stagenet/sepolia users to a mainnet endpoint
 		ec, err = ethclient.Dial(mainnetEndpoint)
 		if err != nil {
 			return nil, err
@@ -85,8 +85,8 @@ func GetXMRUSDPrice(ctx context.Context, ec *ethclient.Client) (*PriceFeed, erro
 	switch chainID.Uint64() {
 	case common.MainnetChainID:
 		// No extra work to do
-	case common.GoerliChainID:
-		// Push stagenet/goerli users to a mainnet endpoint
+	case common.SepoliaChainID:
+		// Push stagenet/sepolia users to a mainnet endpoint
 		ec, err = ethclient.Dial(mainnetEndpoint)
 		if err != nil {
 			return nil, err

--- a/scripts/setup-stagenet.sh
+++ b/scripts/setup-stagenet.sh
@@ -8,7 +8,7 @@ bash ./scripts/install-monero-linux.sh
 # invoking this script. There is no guarantee that the node below will be
 # running or should be trusted when you test.
 #
-ETHEREUM_ENDPOINT="${ETHEREUM_ENDPOINT:-"https://ethereum-goerli-rpc.allthatnode.com"}"
+ETHEREUM_ENDPOINT="${ETHEREUM_ENDPOINT:-"https://rpc.sepolia.org/"}"
 
 #
 # swapd has some preconfigured stagenet monerod nodes, but the best option


### PR DESCRIPTION
with this PR, we'll be using Sepolia for testnet/stagenet instead of Goerli. It's a lot easier to get SepETH and the public endpoints are more reliable. I've personally been using the PoW faucet.

closes #359