### PR TITLE
remove `swap_refund` in favour of `swap_cancel`

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -234,21 +234,8 @@ var (
 				},
 			},
 			{
-				Name:   "refund",
-				Usage:  "If we are the ETH provider for an ongoing swap, refund it if possible.",
-				Action: runRefund,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap to retrieve info for",
-						Required: true,
-					},
-					swapdPortFlag,
-				},
-			},
-			{
 				Name:   "cancel",
-				Usage:  "Cancel a ongoing swap if possible.",
+				Usage:  "Cancel a ongoing swap if possible. Depending on the swap stage, this may not be possible.",
 				Action: runCancel,
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -733,22 +720,6 @@ func runGetPastSwap(ctx *cli.Context) error {
 	return nil
 }
 
-func runRefund(ctx *cli.Context) error {
-	offerID, err := types.HexToHash(ctx.String(flagOfferID))
-	if err != nil {
-		return errInvalidFlagValue(flagOfferID, err)
-	}
-
-	c := newRRPClient(ctx)
-	resp, err := c.Refund(offerID)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Refunded successfully, transaction hash: %s\n", resp.TxHash)
-	return nil
-}
-
 func runCancel(ctx *cli.Context) error {
 	offerID, err := types.HexToHash(ctx.String(flagOfferID))
 	if err != nil {
@@ -756,6 +727,7 @@ func runCancel(ctx *cli.Context) error {
 	}
 
 	c := newRRPClient(ctx)
+	fmt.Printf("Attempting to exit swap with id %s\n", offerID)
 	resp, err := c.Cancel(offerID)
 	if err != nil {
 		return err

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -362,10 +362,10 @@ curl -X POST http://127.0.0.1:5002 -d '{"jsonrpc":"2.0","id":"0","method":"perso
 
 ### `swap_cancel`
 
-Attempts to cancel an ongoing swap.
+Attempts to cancel an ongoing swap. Note that depending on the swap's stage, it may not be possible to cancel the swap and receive a refund.
 
 Parameters:
-- `id`: id of the swap to refund
+- `id`: id of the swap to cancel.
 
 Returns:
 - `status`: exit status of the swap.

--- a/protocol/xmrtaker/errors.go
+++ b/protocol/xmrtaker/errors.go
@@ -15,7 +15,6 @@ var (
 	errMissingProvidedAmount   = errors.New("did not receive provided amount")
 	errMissingAddress          = errors.New("did not receive XMRMaker's address")
 	errNoClaimLogsFound        = errors.New("no Claimed logs found")
-	errCannotRefund            = errors.New("swap is not at a stage where it can refund")
 	errRefundInvalid           = errors.New("cannot refund, swap does not exist")
 	errRefundSwapCompleted     = fmt.Errorf("cannot refund, %w", errSwapCompleted)
 	errCounterpartyKeysNotSet  = errors.New("counterparty's keys aren't set")

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	logging "github.com/ipfs/go-log"
 
 	"github.com/athanorlabs/atomic-swap/coins"
@@ -209,20 +208,6 @@ func (inst *Instance) completeSwap(s *swap.Info, skB *mcrypto.PrivateSpendKey) e
 	}
 
 	return nil
-}
-
-// Refund is called by the RPC function swap_refund.
-// If it's possible to refund the ongoing swap, it does that, then notifies the counterparty.
-func (inst *Instance) Refund(offerID types.Hash) (ethcommon.Hash, error) {
-	inst.swapMu.Lock()
-	defer inst.swapMu.Unlock()
-
-	s, has := inst.swapStates[offerID]
-	if !has {
-		return ethcommon.Hash{}, errNoOngoingSwap
-	}
-
-	return s.doRefund()
 }
 
 // GetOngoingSwapState ...

--- a/protocol/xmrtaker/instance_test.go
+++ b/protocol/xmrtaker/instance_test.go
@@ -33,7 +33,7 @@ func TestNewInstance(t *testing.T) {
 	inst := newTestInstance(t)
 	assert.Nil(t, inst.GetOngoingSwapState(types.EmptyHash))
 	assert.Equal(t, inst.Provides(), coins.ProvidesETH)
-	_, err := inst.Refund(types.EmptyHash)
+	_, err := inst.ExternalSender(types.EmptyHash)
 	assert.ErrorIs(t, err, errNoOngoingSwap)
 }
 

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -413,25 +413,6 @@ func (s *swapState) exit() error {
 	}
 }
 
-// doRefund is called by the RPC function swap_refund.
-// If it's possible to refund the ongoing swap, it does that, then notifies the counterparty.
-func (s *swapState) doRefund() (ethcommon.Hash, error) {
-	switch s.nextExpectedEvent {
-	case EventXMRLockedType, EventETHClaimedType:
-		event := newEventShouldRefund()
-		s.eventCh <- event
-		err := <-event.errCh
-		if err != nil {
-			return ethcommon.Hash{}, err
-		}
-
-		txHash := <-event.txHashCh
-		return txHash, nil
-	default:
-		return ethcommon.Hash{}, errCannotRefund
-	}
-}
-
 func (s *swapState) tryRefund() (ethcommon.Hash, error) {
 	stage, err := s.Contract().Swaps(s.ETHClient().CallOpts(s.ctx), s.contractSwapID)
 	if err != nil {

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -8,9 +8,6 @@ var (
 	// net_ errors
 	errNoOfferWithID = errors.New("peer does not have offer with given ID")
 
-	// swap_ errors
-	errCannotRefund = errors.New("cannot refund if not the ETH provider")
-
 	// ws errors
 	errUnimplemented = errors.New("unimplemented")
 	errInvalidMethod = errors.New("invalid method")

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/MarinX/monerorpc/wallet"
 	"github.com/cockroachdb/apd/v3"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/rpc/v2"
@@ -174,7 +173,6 @@ type ProtocolBackend interface {
 type XMRTaker interface {
 	Protocol
 	InitiateProtocol(providesAmount *apd.Decimal, offer *types.Offer) (common.SwapState, error)
-	Refund(types.Hash) (ethcommon.Hash, error)
 	ExternalSender(offerID types.Hash) (*txsender.ExternalSender, error)
 }
 

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -194,37 +194,6 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 	return nil
 }
 
-// RefundRequest ...
-type RefundRequest struct {
-	OfferID types.Hash `json:"offerID" validate:"required"`
-}
-
-// RefundResponse ...
-type RefundResponse struct {
-	TxHash string `json:"transactionHash" validate:"required"`
-}
-
-// Refund refunds the ongoing swap if we are the ETH provider.
-// TODO: remove in favour of swap_cancel?
-func (s *SwapService) Refund(_ *http.Request, req *RefundRequest, resp *RefundResponse) error {
-	info, err := s.sm.GetOngoingSwap(req.OfferID)
-	if err != nil {
-		return err
-	}
-
-	if info.Provides != coins.ProvidesETH {
-		return errCannotRefund
-	}
-
-	txHash, err := s.xmrtaker.Refund(req.OfferID)
-	if err != nil {
-		return fmt.Errorf("failed to refund: %w", err)
-	}
-
-	resp.TxHash = txHash.String()
-	return nil
-}
-
 // GetStatusRequest ...
 type GetStatusRequest struct {
 	ID types.Hash `json:"id" validate:"required"`

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -44,24 +44,6 @@ func (c *Client) GetPastSwap(id *types.Hash) (*rpc.GetPastResponse, error) {
 	return res, nil
 }
 
-// Refund calls swap_refund
-func (c *Client) Refund(id types.Hash) (*rpc.RefundResponse, error) {
-	const (
-		method = "swap_refund"
-	)
-
-	req := &rpc.RefundRequest{
-		OfferID: id,
-	}
-	res := &rpc.RefundResponse{}
-
-	if err := c.Post(method, req, res); err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
 // GetStatus calls swap_getStatus
 func (c *Client) GetStatus(id types.Hash) (*rpc.GetStatusResponse, error) {
 	const (


### PR DESCRIPTION
These two functions essentially did the same thing, except `swap_refund` was xmrtaker-only. 