### PR TITLE
add AUTHORS file and update copyright in license header

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,17 @@
+# This is the list of AthanorLabs/atomic-swap contributors for copyright purposes.
+# This list can be generated with:
+# git log --format='%aN <%aE>' | sort -uf
+
+Aleixo Sánchez <15819210+alxs@users.noreply.github.com>
+Dmitry Holodov <dimalinux@protonmail.com>
+doonte <111110597+doonte@users.noreply.github.com>
+Janaka-Steph <kakobaba1212@protonmail.com>
+Marcin Górny <marcin.gorny.94@protonmail.com>
+Matthew Di Ferrante <mattdf@users.noreply.github.com>
+Matt <stubbrn@protonmail.com>
+noot <36753753+noot@users.noreply.github.com>
+Oldzitoja <109732715+Oldzitoja@users.noreply.github.com>
+omahs <73983677+omahs@users.noreply.github.com>
+phazejeff <85849384+phazejeff@users.noreply.github.com>
+Robert Hambrock <roberthambrock@gmail.com>
+Thibaut Sardan <33178835+Tbaut@users.noreply.github.com>

--- a/cliutil/utils.go
+++ b/cliutil/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package cliutil provides utility functions intended for sharing by the main packages of multiple executables.

--- a/cliutil/utils_test.go
+++ b/cliutil/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package cliutil

--- a/cmd/swapcli/errors.go
+++ b/cmd/swapcli/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package main provides the entrypoint of swapcli, an executable for interacting with a

--- a/cmd/swapd/contract.go
+++ b/cmd/swapd/contract.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapd/contract_test.go
+++ b/cmd/swapd/contract_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package main provides the entrypoint of the swapd executable, a daemon that

--- a/cmd/swapd/main_test.go
+++ b/cmd/swapd/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapd/profile.go
+++ b/cmd/swapd/profile.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapd/signal_handler.go
+++ b/cmd/swapd/signal_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swapd/signal_handler_test.go
+++ b/cmd/swapd/signal_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package main

--- a/cmd/swaptester/main.go
+++ b/cmd/swaptester/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package main provides the entrypoint of swaptester, an executable used for

--- a/coins/coins.go
+++ b/coins/coins.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package coins provides types, conversions and exchange calculations for dealing

--- a/coins/coins_test.go
+++ b/coins/coins_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/common.go
+++ b/coins/common.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/common_test.go
+++ b/coins/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/errors.go
+++ b/coins/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/exchange_rate.go
+++ b/coins/exchange_rate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/exchange_rate_test.go
+++ b/coins/exchange_rate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/exponent.go
+++ b/coins/exponent.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/exponent_test.go
+++ b/coins/exponent_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/provides.go
+++ b/coins/provides.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/provides_test.go
+++ b/coins/provides_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/round.go
+++ b/coins/round.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/round_test.go
+++ b/coins/round_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/test_support.go
+++ b/coins/test_support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build !prod

--- a/coins/validate.go
+++ b/coins/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/coins/validate_test.go
+++ b/coins/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package coins

--- a/common/config.go
+++ b/common/config.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/consts.go
+++ b/common/consts.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package common is for miscellaneous constants, types and interfaces used by many packages.

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/network.go
+++ b/common/network.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/network_test.go
+++ b/common/network_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/rpctypes/jsonrpc.go
+++ b/common/rpctypes/jsonrpc.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpctypes

--- a/common/rpctypes/types.go
+++ b/common/rpctypes/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package rpctypes provides the serialized types for queries and responses shared by

--- a/common/rpctypes/utils.go
+++ b/common/rpctypes/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpctypes

--- a/common/types/ethasset.go
+++ b/common/types/ethasset.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/types/ethasset_test.go
+++ b/common/types/ethasset_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/types/hash.go
+++ b/common/types/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/types/offer.go
+++ b/common/types/offer.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/types/offer_test.go
+++ b/common/types/offer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/types/status.go
+++ b/common/types/status.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package types is for types that are shared by multiple packages

--- a/common/types/status_test.go
+++ b/common/types/status_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package types

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/common/vjson/validated_json.go
+++ b/common/vjson/validated_json.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package vjson

--- a/common/vjson/validated_json_test.go
+++ b/common/vjson/validated_json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package vjson or "validated JSON" provides additional validation, configured

--- a/crypto/hash.go
+++ b/crypto/hash.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package crypto is for cryptographic code used by both Monero and Ethereum.

--- a/crypto/monero/address.go
+++ b/crypto/monero/address.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/address_marshal.go
+++ b/crypto/monero/address_marshal.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/address_marshal_test.go
+++ b/crypto/monero/address_marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/address_test.go
+++ b/crypto/monero/address_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/base58.go
+++ b/crypto/monero/base58.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/base58_test.go
+++ b/crypto/monero/base58_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/crypto.go
+++ b/crypto/monero/crypto.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package mcrypto is for types and libraries that deal with Monero keys, addresses and

--- a/crypto/monero/crypto_marshal.go
+++ b/crypto/monero/crypto_marshal.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/crypto_marshal_test.go
+++ b/crypto/monero/crypto_marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/crypto_test.go
+++ b/crypto/monero/crypto_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/sc_reduce.go
+++ b/crypto/monero/sc_reduce.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/monero/sc_reduce_test.go
+++ b/crypto/monero/sc_reduce_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package mcrypto

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package secp256k1 contains methods and types for working with Ethereum and possibly other

--- a/crypto/secp256k1/secp256k1_test.go
+++ b/crypto/secp256k1/secp256k1_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package secp256k1

--- a/daemon/swap_daemon.go
+++ b/daemon/swap_daemon.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package daemon is responsible for assembling, running and cleanly shutting

--- a/daemon/swap_daemon_test.go
+++ b/daemon/swap_daemon_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package daemon

--- a/daemon/test_support.go
+++ b/daemon/test_support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build !prod

--- a/db/database.go
+++ b/db/database.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package db implements the APIs for interacting with our disk persisted key-value store.

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package db

--- a/db/recovery_db.go
+++ b/db/recovery_db.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package db

--- a/db/recovery_db_test.go
+++ b/db/recovery_db_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package db

--- a/db/types.go
+++ b/db/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package db

--- a/dleq/dleq.go
+++ b/dleq/dleq.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package dleq provides a sub-api built on top of the go-dleq package for our atomic

--- a/dleq/go_dleq.go
+++ b/dleq/go_dleq.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package dleq

--- a/dleq/go_dleq_test.go
+++ b/dleq/go_dleq_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package dleq

--- a/ethereum/block/error_from_block.go
+++ b/ethereum/block/error_from_block.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package block

--- a/ethereum/block/wait_for_receipt.go
+++ b/ethereum/block/wait_for_receipt.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package block

--- a/ethereum/block/wait_for_receipt_test.go
+++ b/ethereum/block/wait_for_receipt_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package block

--- a/ethereum/block/wait_for_timestamp.go
+++ b/ethereum/block/wait_for_timestamp.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package block contains ethereum helper methods that center around blocks, like waiting

--- a/ethereum/block/wait_for_timestamp_test.go
+++ b/ethereum/block/wait_for_timestamp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package block

--- a/ethereum/check_swap_creator_contract.go
+++ b/ethereum/check_swap_creator_contract.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/check_swap_creator_contract_test.go
+++ b/ethereum/check_swap_creator_contract_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/deploy_util.go
+++ b/ethereum/deploy_util.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/deploy_util_test.go
+++ b/ethereum/deploy_util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/erc20_mock_test.go
+++ b/ethereum/erc20_mock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/extethclient/eth_wallet_client.go
+++ b/ethereum/extethclient/eth_wallet_client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package extethclient provides libraries for interacting with an ethereum node

--- a/ethereum/extethclient/eth_wallet_client_test.go
+++ b/ethereum/extethclient/eth_wallet_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package extethclient

--- a/ethereum/extethclient/test_support.go
+++ b/ethereum/extethclient/test_support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build !prod

--- a/ethereum/swap_creator_marshal.go
+++ b/ethereum/swap_creator_marshal.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/swap_creator_marshal_test.go
+++ b/ethereum/swap_creator_marshal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/swap_creator_test.go
+++ b/ethereum/swap_creator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/utils.go
+++ b/ethereum/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package contracts is for go bindings generated from Solidity contracts as well as

--- a/ethereum/utils_test.go
+++ b/ethereum/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package contracts

--- a/ethereum/watcher/watcher.go
+++ b/ethereum/watcher/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package watcher provides tools to track events emitted from ethereum contracts.

--- a/monero/mine_regtest.go
+++ b/monero/mine_regtest.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package monero

--- a/monero/test_support.go
+++ b/monero/test_support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build !prod

--- a/monero/utils.go
+++ b/monero/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package monero

--- a/monero/utils_test.go
+++ b/monero/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package monero

--- a/monero/wallet_client.go
+++ b/monero/wallet_client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package monero provides client libraries for working with wallet files and interacting

--- a/monero/wallet_client_pdeathsig.go
+++ b/monero/wallet_client_pdeathsig.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build linux || freebsd

--- a/monero/wallet_client_test.go
+++ b/monero/wallet_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package monero

--- a/net/errors.go
+++ b/net/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/host.go
+++ b/net/host.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package net adds swap-specific functionality to go-p2p-net/Host,

--- a/net/host_test.go
+++ b/net/host_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/initiate.go
+++ b/net/initiate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/initiate_test.go
+++ b/net/initiate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/message/message.go
+++ b/net/message/message.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package message provides the types for messages that are sent between swapd instances.

--- a/net/message/relay_message.go
+++ b/net/message/relay_message.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package message

--- a/net/query.go
+++ b/net/query.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/query_test.go
+++ b/net/query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/relay.go
+++ b/net/relay.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/relay_test.go
+++ b/net/relay_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/net/types.go
+++ b/net/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package net

--- a/pricefeed/pricefeed.go
+++ b/pricefeed/pricefeed.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package pricefeed implements routines to retrieve on-chain price feeds from chainlink's

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package pricefeed

--- a/protocol/backend/backend.go
+++ b/protocol/backend/backend.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package backend provides the portion of top-level swapd instance

--- a/protocol/backend/backend_test.go
+++ b/protocol/backend/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package backend

--- a/protocol/backend/errors.go
+++ b/protocol/backend/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package backend

--- a/protocol/backend/mocks_generate_test.go
+++ b/protocol/backend/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package backend

--- a/protocol/claim_monero.go
+++ b/protocol/claim_monero.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/claim_monero_test.go
+++ b/protocol/claim_monero_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/common.go
+++ b/protocol/common.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package protocol has functions that are used by both the maker and taker during execution of the swap.

--- a/protocol/common_test.go
+++ b/protocol/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/ethereum_asset_amount.go
+++ b/protocol/ethereum_asset_amount.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/swap/database.go
+++ b/protocol/swap/database.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package swap

--- a/protocol/swap/manager.go
+++ b/protocol/swap/manager.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package swap provides the management layer used by swapd for tracking current and past

--- a/protocol/swap/manager_test.go
+++ b/protocol/swap/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package swap

--- a/protocol/swap/mocks_generate_test.go
+++ b/protocol/swap/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package swap

--- a/protocol/swap/types.go
+++ b/protocol/swap/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package swap

--- a/protocol/swap/types_test.go
+++ b/protocol/swap/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package swap

--- a/protocol/txsender/external_sender.go
+++ b/protocol/txsender/external_sender.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package txsender

--- a/protocol/txsender/sender.go
+++ b/protocol/txsender/sender.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package txsender provides a common Sender interface for swapd instances. Each Sender

--- a/protocol/utils.go
+++ b/protocol/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package protocol

--- a/protocol/xmrmaker/backend_offers.go
+++ b/protocol/xmrmaker/backend_offers.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/checks.go
+++ b/protocol/xmrmaker/checks.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/claim.go
+++ b/protocol/xmrmaker/claim.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/claim_test.go
+++ b/protocol/xmrmaker/claim_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/errors.go
+++ b/protocol/xmrmaker/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/event.go
+++ b/protocol/xmrmaker/event.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/event_test.go
+++ b/protocol/xmrmaker/event_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/mocks_generate_test.go
+++ b/protocol/xmrmaker/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/net.go
+++ b/protocol/xmrmaker/net.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/net_test.go
+++ b/protocol/xmrmaker/net_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/offers/database.go
+++ b/protocol/xmrmaker/offers/database.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package offers

--- a/protocol/xmrmaker/offers/mocks_generate_test.go
+++ b/protocol/xmrmaker/offers/mocks_generate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package offers

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package offers provides management of the offers being made by a swapd instance.

--- a/protocol/xmrmaker/offers/offer_manager_test.go
+++ b/protocol/xmrmaker/offers/offer_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package offers

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package xmrmaker manages the swap state of individual swaps where the local swapd

--- a/protocol/xmrmaker/swap_state_ongoing_test.go
+++ b/protocol/xmrmaker/swap_state_ongoing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrmaker/watcher.go
+++ b/protocol/xmrmaker/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrmaker

--- a/protocol/xmrtaker/claim.go
+++ b/protocol/xmrtaker/claim.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/errors.go
+++ b/protocol/xmrtaker/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/event.go
+++ b/protocol/xmrtaker/event.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/event_test.go
+++ b/protocol/xmrtaker/event_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/instance_test.go
+++ b/protocol/xmrtaker/instance_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/net.go
+++ b/protocol/xmrtaker/net.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/net_test.go
+++ b/protocol/xmrtaker/net_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package xmrtaker manages the swap state of individual swaps where the local swapd

--- a/protocol/xmrtaker/swap_state_ongoing_test.go
+++ b/protocol/xmrtaker/swap_state_ongoing_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/protocol/xmrtaker/watcher.go
+++ b/protocol/xmrtaker/watcher.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package xmrtaker

--- a/relayer/claim_request.go
+++ b/relayer/claim_request.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package relayer provides libraries for creating and validating relay requests and responses.

--- a/relayer/claim_request_test.go
+++ b/relayer/claim_request_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package relayer

--- a/relayer/forwarder.go
+++ b/relayer/forwarder.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package relayer

--- a/relayer/submit_transaction.go
+++ b/relayer/submit_transaction.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package relayer

--- a/relayer/validate.go
+++ b/relayer/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package relayer

--- a/relayer/validate_test.go
+++ b/relayer/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package relayer

--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/net.go
+++ b/rpc/net.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/net_test.go
+++ b/rpc/net_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/personal.go
+++ b/rpc/personal.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package rpc provides the HTTP server for incoming JSON-RPC and websocket requests to

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/ws.go
+++ b/rpc/ws.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpc/ws_test.go
+++ b/rpc/ws_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/rpcclient/addresses.go
+++ b/rpcclient/addresses.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/cancel.go
+++ b/rpcclient/cancel.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/client.go
+++ b/rpcclient/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package rpcclient provides client libraries for interacting with a local swapd instance using

--- a/rpcclient/discover.go
+++ b/rpcclient/discover.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/get_offers.go
+++ b/rpcclient/get_offers.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/make_offer.go
+++ b/rpcclient/make_offer.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/peers.go
+++ b/rpcclient/peers.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/personal.go
+++ b/rpcclient/personal.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/query.go
+++ b/rpcclient/query.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/take_offer.go
+++ b/rpcclient/take_offer.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package rpcclient

--- a/rpcclient/wsclient/wsclient.go
+++ b/rpcclient/wsclient/wsclient.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package wsclient provides client libraries for interacting with a local swapd instance

--- a/tests/erc20_integration_test.go
+++ b/tests/erc20_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package tests

--- a/tests/ganache.go
+++ b/tests/ganache.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package tests

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 // Package tests provides integration tests, which exercise fully built swapd instances

--- a/tests/relayer_integration_test.go
+++ b/tests/relayer_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Athanor Labs (ON)
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
 // SPDX-License-Identifier: LGPL-3.0-only
 
 package tests


### PR DESCRIPTION
As title says. this approach is used by many other open source projects for copyright purposes, for example, [go-ethereum](https://github.com/ethereum/go-ethereum). While this list was always implicitly in the contributors section of the repo, this makes it more explicit. This document from google open source is a good explainer: https://opensource.google/documentation/reference/releasing/authors 

Also linking this open-source authorship case study as I found it quite interesting: https://google.github.io/opencasebook/authorship/ 