### PR TITLE
fix: update event watcher to not checks blocks twice

### DIFF
--- a/ethereum/watcher/watcher.go
+++ b/ethereum/watcher/watcher.go
@@ -111,7 +111,9 @@ func (f *EventFilter) Start() error {
 				f.logCh <- l
 			}
 
-			f.filterQuery.FromBlock = currHeader.Number
+			// the filter query is inclusive of the `FromBlock`, so we already checked `FromBlock`
+			// and we don't want to check it again, so increment by 1
+			f.filterQuery.FromBlock = big.NewInt(0).Add(currHeader.Number, big.NewInt(1))
 		}
 	}()
 

--- a/ethereum/watcher/watcher.go
+++ b/ethereum/watcher/watcher.go
@@ -111,7 +111,7 @@ func (f *EventFilter) Start() error {
 				f.logCh <- l
 			}
 
-			// the filter query is inclusive of the `FromBlock`, so we already checked `FromBlock`
+			// the filter query is inclusive of the `ToBlock`, so we already checked `ToBlock`
 			// and we don't want to check it again, so increment by 1
 			f.filterQuery.FromBlock = big.NewInt(0).Add(currHeader.Number, big.NewInt(1))
 		}

--- a/protocol/xmrmaker/watcher.go
+++ b/protocol/xmrmaker/watcher.go
@@ -37,7 +37,6 @@ func (s *swapState) runContractEventWatcher() {
 func (s *swapState) handleReadyLogs(l *ethtypes.Log) error {
 	err := pcommon.CheckSwapID(l, readyTopic, s.contractSwapID)
 	if errors.Is(err, pcommon.ErrLogNotForUs) {
-		log.Infof("log not for us")
 		return nil
 	}
 	if err != nil {
@@ -59,7 +58,6 @@ func (s *swapState) handleReadyLogs(l *ethtypes.Log) error {
 func (s *swapState) handleRefundLogs(ethlog *ethtypes.Log) error {
 	err := pcommon.CheckSwapID(ethlog, refundedTopic, s.contractSwapID)
 	if errors.Is(err, pcommon.ErrLogNotForUs) {
-		log.Warnf("ErrLogNotForUs")
 		return nil
 	}
 	if err != nil {
@@ -72,7 +70,6 @@ func (s *swapState) handleRefundLogs(ethlog *ethtypes.Log) error {
 	}
 
 	// swap was refunded, send EventRefunded
-	log.Infof("sending EventETHRefunded in s.eventCh")
 	event := newEventETHRefunded(sk)
 	s.eventCh <- event
 	return <-event.errCh


### PR DESCRIPTION
as title says, the reason we were seeing a bad log was because the event watcher was checking the same block twice, thus triggering the `Claimed` event handler twice, resulting in duplicate `EventETHClaimed` events

closes #381 