### PR TITLE
feat: swapcli commands to manually claim/refund and for database functions

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -291,34 +291,6 @@ func cliApp() *cli.App {
 				},
 			},
 			{
-				Name: "claim",
-				Usage: "manually call claim() in the contract for a given swap. " +
-					"WARNING: This should only be used if the normal swap process fails.",
-				Action: runClaim,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap for which to call claim()",
-						Required: true,
-					},
-					swapdPortFlag,
-				},
-			},
-			{
-				Name: "refund",
-				Usage: "manually call refund() in the contract for a given swap. " +
-					"WARNING: This should only be used if the normal swap process fails.",
-				Action: runRefund,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap for which to call refund()",
-						Required: true,
-					},
-					swapdPortFlag,
-				},
-			},
-			{
 				Name:   "set-swap-timeout",
 				Usage:  "Set the duration between swap initiation and t0 and t0 and t1, in seconds",
 				Action: runSetSwapTimeout,
@@ -346,38 +318,6 @@ func cliApp() *cli.App {
 				},
 			},
 			{
-				Name: "get-contract-swap-info",
-				Usage: "Get information about a swap needed to call the contract functions. " +
-					"Returns the contract address, the swap's struct as represented in the contract, " +
-					"and the hash of the swap's struct, which is used as its contract identifier. " +
-					"Note: this is only useful if you plan to manually call the contract functions.",
-				Action: runGetContractSwapInfo,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap for which query for",
-						Required: true,
-					},
-					swapdPortFlag,
-				},
-			},
-			{
-				Name: "get-swap-secret",
-				Usage: "Get the secret for a swap. " +
-					"WARNING: do NOT share this secret with anyone. Doing so may result in a loss of funds. " +
-					"You should not use this function unless you are sure of what you're doing. " +
-					"This function is only useful if you plan to try to manually recover funds.",
-				Action: runGetSwapSecret,
-				Flags: []cli.Flag{
-					&cli.StringFlag{
-						Name:     flagOfferID,
-						Usage:    "ID of swap for which to get the secret for",
-						Required: true,
-					},
-					swapdPortFlag,
-				},
-			},
-			{
 				Name:   "version",
 				Usage:  "Get the client and server versions",
 				Action: runGetVersions,
@@ -391,6 +331,74 @@ func cliApp() *cli.App {
 				Action: runShutdown,
 				Flags: []cli.Flag{
 					swapdPortFlag,
+				},
+			},
+			{
+				Name:  "recovery",
+				Usage: "Methods that should only be used as a last resort in the case of an unrecoverable swap error.",
+				Subcommands: []*cli.Command{
+					{
+						Name: "get-contract-swap-info",
+						Usage: "Get information about a swap needed to call the contract functions.\n" +
+							"Returns the contract address, the swap's struct as represented in the contract,\n" +
+							"and the hash of the swap's struct, which is used as its contract identifier.\n" +
+							"Note: this is only useful if you plan to manually call the contract functions.",
+						Action: runGetContractSwapInfo,
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     flagOfferID,
+								Usage:    "ID of swap for which query for",
+								Required: true,
+							},
+							swapdPortFlag,
+						},
+					},
+					{
+						Name: "get-swap-secret",
+						Usage: "Get the secret for a swap.\n" +
+							"WARNING: do NOT share this secret with anyone. Doing so may result in a loss of funds.\n" +
+							"You should not use this function unless you are sure of what you're doing.\n" +
+							"This function is only useful if you plan to try to manually recover funds.",
+						Action: runGetSwapSecret,
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     flagOfferID,
+								Usage:    "ID of swap for which to get the secret for",
+								Required: true,
+							},
+							swapdPortFlag,
+						},
+					},
+					{
+						Name: "claim",
+						Usage: "Manually call claim() in the contract for a given swap.\n" +
+							"WARNING: This should only be used as a last resort if the normal swap process fails\n" +
+							"and restarting the node does not resolve the issue.",
+						Action: runClaim,
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     flagOfferID,
+								Usage:    "ID of swap for which to call claim()",
+								Required: true,
+							},
+							swapdPortFlag,
+						},
+					},
+					{
+						Name: "refund",
+						Usage: "Manually call refund() in the contract for a given swap.\n" +
+							"WARNING: This should only be used as a last resort if the normal swap process fails\n" +
+							"and restarting the node does not resolve the issue.",
+						Action: runRefund,
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     flagOfferID,
+								Usage:    "ID of swap for which to call refund()",
+								Required: true,
+							},
+							swapdPortFlag,
+						},
+					},
 				},
 			},
 		},

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -291,6 +291,32 @@ func cliApp() *cli.App {
 				},
 			},
 			{
+				Name:   "claim",
+				Usage:  "manually call claim() in the contract for a given swap. This should only be used if the normal swap process fails.",
+				Action: runClaim,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     flagOfferID,
+						Usage:    "ID of swap for which to call claim()",
+						Required: true,
+					},
+					swapdPortFlag,
+				},
+			},
+			{
+				Name:   "refund",
+				Usage:  "manually call refund() in the contract for a given swap. This should only be used if the normal swap process fails.",
+				Action: runRefund,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     flagOfferID,
+						Usage:    "ID of swap for which to call refund()",
+						Required: true,
+					},
+					swapdPortFlag,
+				},
+			},
+			{
 				Name:   "set-swap-timeout",
 				Usage:  "Set the duration between swap initiation and t0 and t0 and t1, in seconds",
 				Action: runSetSwapTimeout,
@@ -875,6 +901,38 @@ func runGetStatus(ctx *cli.Context) error {
 
 	fmt.Printf("Start time: %s\n", resp.StartTime.Format(common.TimeFmtSecs))
 	fmt.Printf("Status=%s: %s\n", resp.Status, resp.Description)
+	return nil
+}
+
+func runClaim(ctx *cli.Context) error {
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
+
+	c := newRRPClient(ctx)
+	resp, err := c.Claim(offerID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Transaction hash: %s\n", resp.TxHash)
+	return nil
+}
+
+func runRefund(ctx *cli.Context) error {
+	offerID, err := types.HexToHash(ctx.String(flagOfferID))
+	if err != nil {
+		return errInvalidFlagValue(flagOfferID, err)
+	}
+
+	c := newRRPClient(ctx)
+	resp, err := c.Refund(offerID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Transaction hash: %s\n", resp.TxHash)
 	return nil
 }
 

--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -292,7 +292,7 @@ func cliApp() *cli.App {
 			},
 			{
 				Name: "claim",
-				Usage: "manually call claim() in the contract for a given swap." +
+				Usage: "manually call claim() in the contract for a given swap. " +
 					"WARNING: This should only be used if the normal swap process fails.",
 				Action: runClaim,
 				Flags: []cli.Flag{
@@ -306,7 +306,7 @@ func cliApp() *cli.App {
 			},
 			{
 				Name: "refund",
-				Usage: "manually call refund() in the contract for a given swap." +
+				Usage: "manually call refund() in the contract for a given swap. " +
 					"WARNING: This should only be used if the normal swap process fails.",
 				Action: runRefund,
 				Flags: []cli.Flag{
@@ -348,14 +348,14 @@ func cliApp() *cli.App {
 			{
 				Name: "get-contract-swap-info",
 				Usage: "Get information about a swap needed to call the contract functions. " +
-					"Returns the contract address, the swap's struct as represented in the contract," +
-					"and the hash of the swap's struct, which is used as its contract identifier." +
+					"Returns the contract address, the swap's struct as represented in the contract, " +
+					"and the hash of the swap's struct, which is used as its contract identifier. " +
 					"Note: this is only useful if you plan to manually call the contract functions.",
 				Action: runGetContractSwapInfo,
 				Flags: []cli.Flag{
-					&cli.UintFlag{
-						Name:     "duration",
-						Usage:    "Duration of timeout, in seconds",
+					&cli.StringFlag{
+						Name:     flagOfferID,
+						Usage:    "ID of swap for which query for",
 						Required: true,
 					},
 					swapdPortFlag,
@@ -364,14 +364,14 @@ func cliApp() *cli.App {
 			{
 				Name: "get-swap-secret",
 				Usage: "Get the secret for a swap. " +
-					"WARNING: do NOT share this secret with anyone. Doing so may result in a loss of funds." +
-					"You should not use this function unless you are sure of what you're doing." +
+					"WARNING: do NOT share this secret with anyone. Doing so may result in a loss of funds. " +
+					"You should not use this function unless you are sure of what you're doing. " +
 					"This function is only useful if you plan to try to manually recover funds.",
 				Action: runGetSwapSecret,
 				Flags: []cli.Flag{
-					&cli.UintFlag{
-						Name:     "duration",
-						Usage:    "Duration of timeout, in seconds",
+					&cli.StringFlag{
+						Name:     flagOfferID,
+						Usage:    "ID of swap for which to get the secret for",
 						Required: true,
 					},
 					swapdPortFlag,

--- a/daemon/double_restart_test.go
+++ b/daemon/double_restart_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package daemon
 
 import (

--- a/daemon/manual_tx_test.go
+++ b/daemon/manual_tx_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test if Alice is able to manually call `refund()` via swapcli.
+// Test if Alice is able to call the Refund() RPC API (used by swapcli refund) immediately after locking her ETH.
 func TestRunSwapDaemon_ManualRefund(t *testing.T) {
 	minXMR := coins.StrToDecimal("1")
 	maxXMR := minXMR

--- a/daemon/manual_tx_test.go
+++ b/daemon/manual_tx_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package daemon
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/athanorlabs/atomic-swap/coins"
+	"github.com/athanorlabs/atomic-swap/common"
+	"github.com/athanorlabs/atomic-swap/common/types"
+	"github.com/athanorlabs/atomic-swap/ethereum/block"
+	"github.com/athanorlabs/atomic-swap/monero"
+	"github.com/athanorlabs/atomic-swap/rpcclient"
+	"github.com/athanorlabs/atomic-swap/rpcclient/wsclient"
+	"github.com/athanorlabs/atomic-swap/tests"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test if Alice is able to manually call `refund()` via swapcli.
+func TestRunSwapDaemon_ManualRefund(t *testing.T) {
+	minXMR := coins.StrToDecimal("1")
+	maxXMR := minXMR
+	exRate := coins.StrToExchangeRate("0.1")
+	providesAmt, err := exRate.ToETH(minXMR)
+	require.NoError(t, err)
+
+	bobEthKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	bobConf := CreateTestConf(t, bobEthKey)
+	monero.MineMinXMRBalance(t, bobConf.MoneroClient, coins.MoneroToPiconero(maxXMR))
+
+	aliceConf := CreateTestConf(t, tests.GetTakerTestKey(t))
+
+	timeout := 7 * time.Minute
+	ctx, _ := LaunchDaemons(t, timeout, bobConf, aliceConf)
+
+	bc, err := wsclient.NewWsClient(ctx, fmt.Sprintf("ws://127.0.0.1:%d/ws", bobConf.RPCPort))
+	require.NoError(t, err)
+	ac, err := wsclient.NewWsClient(ctx, fmt.Sprintf("ws://127.0.0.1:%d/ws", aliceConf.RPCPort))
+	require.NoError(t, err)
+	acHTTP := rpcclient.NewClient(ctx, fmt.Sprintf("http://127.0.0.1:%d", aliceConf.RPCPort))
+
+	useRelayer := false
+	makeResp, bobStatusCh, err := bc.MakeOfferAndSubscribe(minXMR, maxXMR, exRate, types.EthAssetETH, useRelayer)
+	require.NoError(t, err)
+
+	aliceStatusCh, err := ac.TakeOfferAndSubscribe(makeResp.PeerID, makeResp.OfferID, providesAmt)
+	require.NoError(t, err)
+
+	var statusWG sync.WaitGroup
+	statusWG.Add(2)
+
+	go func() {
+		defer statusWG.Done()
+		for {
+			select {
+			case status := <-aliceStatusCh:
+				t.Log("> Alice got status:", status)
+				if !status.IsOngoing() {
+					assert.Equal(t, types.CompletedRefund.String(), status.String())
+					return
+				}
+
+				if status == types.ETHLocked {
+					// wait for eth lock to get included
+					time.Sleep(time.Second)
+
+					// call refund
+					t.Log("> Alice calling refund")
+					refundResp, err := acHTTP.Refund(makeResp.OfferID)
+					require.NoError(t, err)
+
+					ec, err := ethclient.Dial(common.DefaultEthEndpoint)
+					require.NoError(t, err)
+
+					t.Log("> Alice got refund response tx:", refundResp.TxHash)
+					receipt, err := block.WaitForReceipt(ctx, ec, refundResp.TxHash)
+					require.NoError(t, err)
+					assert.Equal(t, uint64(1), receipt.Status)
+
+					// manually trigger exit, since the xmrtaker doesn't watch for Refunded events.
+					status, err := acHTTP.Cancel(makeResp.OfferID)
+					require.NoError(t, err)
+					assert.Equal(t, types.CompletedRefund.String(), status.String())
+					return
+				}
+			case <-ctx.Done():
+				t.Errorf("Alice's context cancelled before she completed the swap")
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer statusWG.Done()
+		for {
+			select {
+			case status := <-bobStatusCh:
+				t.Log("> Bob got status:", status)
+				if !status.IsOngoing() {
+					assert.Equal(t, types.CompletedRefund.String(), status.String())
+					return
+				}
+			case <-ctx.Done():
+				t.Errorf("Bob's context cancelled before he completed the swap")
+				return
+			}
+		}
+	}()
+
+	statusWG.Wait()
+	if t.Failed() {
+		return
+	}
+}

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"time"
 
 	"github.com/MarinX/monerorpc/wallet"
@@ -193,6 +194,10 @@ func newMockProtocolBackend() *mockProtocolBackend {
 	return &mockProtocolBackend{
 		sm: new(mockSwapManager),
 	}
+}
+
+func (*mockProtocolBackend) Ctx() context.Context {
+	return context.Background()
 }
 
 func (*mockProtocolBackend) Env() common.Environment {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -110,6 +110,7 @@ func NewServer(cfg *Config) (*Server, error) {
 					cfg.XMRMaker,
 					cfg.Net,
 					cfg.ProtocolBackend,
+					cfg.RecoveryDB,
 				),
 				SwapNamespace,
 			)
@@ -215,6 +216,7 @@ type Protocol interface {
 
 // ProtocolBackend represents protocol/backend.Backend
 type ProtocolBackend interface {
+	Ctx() context.Context
 	Env() common.Environment
 	SetSwapTimeout(timeout time.Duration)
 	SwapTimeout() time.Duration

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -345,7 +345,7 @@ func (s *SwapService) Claim(_ *http.Request, req *ManualTransactionRequest, resp
 		return err
 	}
 
-	tx, err := swapCreator.Claim(txOpts, *contractSwapInfo.Swap, [32]byte(secret.Bytes()))
+	tx, err := swapCreator.Claim(txOpts, *contractSwapInfo.Swap, [32]byte(common.Reverse(secret.Bytes())))
 	if err != nil {
 		return err
 	}
@@ -370,6 +370,9 @@ func (s *SwapService) Refund(_ *http.Request, req *ManualTransactionRequest, res
 		return err
 	}
 
+	fmt.Println(contractSwapInfo.Swap)
+	fmt.Println(secret)
+
 	ec := s.backend.ETHClient()
 	swapCreator, err := contracts.NewSwapCreator(contractSwapInfo.SwapCreatorAddr, ec.Raw())
 	if err != nil {
@@ -384,7 +387,7 @@ func (s *SwapService) Refund(_ *http.Request, req *ManualTransactionRequest, res
 		return err
 	}
 
-	tx, err := swapCreator.Refund(txOpts, *contractSwapInfo.Swap, [32]byte(secret.Bytes()))
+	tx, err := swapCreator.Refund(txOpts, *contractSwapInfo.Swap, [32]byte(common.Reverse(secret.Bytes())))
 	if err != nil {
 		return err
 	}

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
+	contracts "github.com/athanorlabs/atomic-swap/ethereum"
 	"github.com/athanorlabs/atomic-swap/pricefeed"
 	"github.com/athanorlabs/atomic-swap/protocol/swap"
 )
@@ -28,6 +29,7 @@ type SwapService struct {
 	xmrmaker XMRMaker
 	net      Net
 	backend  ProtocolBackend
+	rdb      RecoveryDB
 }
 
 // NewSwapService ...
@@ -38,6 +40,7 @@ func NewSwapService(
 	xmrmaker XMRMaker,
 	net Net,
 	b ProtocolBackend,
+	rdb RecoveryDB,
 ) *SwapService {
 	return &SwapService{
 		ctx:      ctx,
@@ -46,6 +49,7 @@ func NewSwapService(
 		xmrmaker: xmrmaker,
 		net:      net,
 		backend:  b,
+		rdb:      rdb,
 	}
 }
 
@@ -297,6 +301,95 @@ func (s *SwapService) Cancel(_ *http.Request, req *CancelRequest, resp *CancelRe
 	}
 
 	resp.Status = past.Status
+	return nil
+}
+
+// ManualTransactionRequest is used to call swap_claim or swap_refund.
+type ManualTransactionRequest struct {
+	OfferID types.Hash `json:"offerID" validate:"required"`
+}
+
+// ManualTransactionResponse is returned from swap_claim or swap_refund and contains
+// the transaction hash of the claim or refund transaction.
+type ManualTransactionResponse struct {
+	TxHash types.Hash `json:"txHash" validate:"required"`
+}
+
+// Claim calls the `claim` method on the swap contract given swap's offer ID.
+// It uses the swap recovery info stored in the database to do so.
+// It does not require the swap to be ongoing.
+// This is meant as a fail-safe in case of some unknown swap error.
+// It returns the transaction hash of the claim transaction.
+func (s *SwapService) Claim(_ *http.Request, req *ManualTransactionRequest, resp *ManualTransactionResponse) error {
+	contractSwapInfo, err := s.rdb.GetContractSwapInfo(req.OfferID)
+	if err != nil {
+		return err
+	}
+
+	secret, err := s.rdb.GetSwapPrivateKey(req.OfferID)
+	if err != nil {
+		return err
+	}
+
+	ec := s.backend.ETHClient()
+	swapCreator, err := contracts.NewSwapCreator(contractSwapInfo.SwapCreatorAddr, ec.Raw())
+	if err != nil {
+		return err
+	}
+
+	ec.Lock()
+	defer ec.Unlock()
+
+	txOpts, err := ec.TxOpts(s.backend.Ctx())
+	if err != nil {
+		return err
+	}
+
+	tx, err := swapCreator.Claim(txOpts, *contractSwapInfo.Swap, [32]byte(secret.Bytes()))
+	if err != nil {
+		return err
+	}
+
+	resp.TxHash = tx.Hash()
+	return nil
+}
+
+// Refund calls the `refund` method on the swap contract given swap's offer ID.
+// It uses the swap recovery info stored in the database to do so.
+// It does not require the swap to be ongoing.
+// This is meant as a fail-safe in case of some unknown swap error.
+// It returns the transaction hash of the refund transaction.
+func (s *SwapService) Refund(_ *http.Request, req *ManualTransactionRequest, resp *ManualTransactionResponse) error {
+	contractSwapInfo, err := s.rdb.GetContractSwapInfo(req.OfferID)
+	if err != nil {
+		return err
+	}
+
+	secret, err := s.rdb.GetSwapPrivateKey(req.OfferID)
+	if err != nil {
+		return err
+	}
+
+	ec := s.backend.ETHClient()
+	swapCreator, err := contracts.NewSwapCreator(contractSwapInfo.SwapCreatorAddr, ec.Raw())
+	if err != nil {
+		return err
+	}
+
+	ec.Lock()
+	defer ec.Unlock()
+
+	txOpts, err := ec.TxOpts(s.backend.Ctx())
+	if err != nil {
+		return err
+	}
+
+	tx, err := swapCreator.Refund(txOpts, *contractSwapInfo.Swap, [32]byte(secret.Bytes()))
+	if err != nil {
+		return err
+	}
+
+	resp.TxHash = tx.Hash()
 	return nil
 }
 

--- a/rpcclient/database.go
+++ b/rpcclient/database.go
@@ -1,0 +1,47 @@
+// Copyright 2023 The AthanorLabs/atomic-swap Authors
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Package rpcclient provides client libraries for interacting with a local swapd instance using
+// the JSON-RPC remote procedure call protocol.
+package rpcclient
+
+import (
+	"github.com/athanorlabs/atomic-swap/common/types"
+	"github.com/athanorlabs/atomic-swap/rpc"
+)
+
+// GetContractSwapInfo calls database_getContractSwapInfo.
+func (c *Client) GetContractSwapInfo(offerID types.Hash) (*rpc.GetContractSwapInfoResponse, error) {
+	const (
+		method = "database_getContractSwapInfo"
+	)
+
+	req := &rpc.GetContractSwapInfoRequest{
+		OfferID: offerID,
+	}
+
+	res := &rpc.GetContractSwapInfoResponse{}
+	if err := c.Post(method, req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// GetSwapSecret calls database_getSwapSecret.
+func (c *Client) GetSwapSecret(offerID types.Hash) (*rpc.GetSwapSecretResponse, error) {
+	const (
+		method = "database_getContractSwapInfo"
+	)
+
+	req := &rpc.GetSwapSecretRequest{
+		OfferID: offerID,
+	}
+
+	res := &rpc.GetSwapSecretResponse{}
+	if err := c.Post(method, req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/rpcclient/database.go
+++ b/rpcclient/database.go
@@ -31,7 +31,7 @@ func (c *Client) GetContractSwapInfo(offerID types.Hash) (*rpc.GetContractSwapIn
 // GetSwapSecret calls database_getSwapSecret.
 func (c *Client) GetSwapSecret(offerID types.Hash) (*rpc.GetSwapSecretResponse, error) {
 	const (
-		method = "database_getContractSwapInfo"
+		method = "database_getSwapSecret"
 	)
 
 	req := &rpc.GetSwapSecretRequest{

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -82,6 +82,42 @@ func (c *Client) ClearOffers(offerIDs []types.Hash) error {
 	return nil
 }
 
+func (c *Client) Claim(offerID types.Hash) (*rpc.ManualTransactionResponse, error) {
+	const (
+		method = "swap_claim"
+	)
+
+	req := &rpc.ManualTransactionRequest{
+		OfferID: offerID,
+	}
+
+	res := &rpc.ManualTransactionResponse{}
+
+	if err := c.Post(method, req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (c *Client) Refund(offerID types.Hash) (*rpc.ManualTransactionResponse, error) {
+	const (
+		method = "swap_refund"
+	)
+
+	req := &rpc.ManualTransactionRequest{
+		OfferID: offerID,
+	}
+
+	res := &rpc.ManualTransactionResponse{}
+
+	if err := c.Post(method, req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // SuggestedExchangeRate calls swap_suggestedExchangeRate
 func (c *Client) SuggestedExchangeRate() (*rpc.SuggestedExchangeRateResponse, error) {
 	const (

--- a/rpcclient/swap.go
+++ b/rpcclient/swap.go
@@ -82,6 +82,7 @@ func (c *Client) ClearOffers(offerIDs []types.Hash) error {
 	return nil
 }
 
+// Claim calls swap_claim
 func (c *Client) Claim(offerID types.Hash) (*rpc.ManualTransactionResponse, error) {
 	const (
 		method = "swap_claim"
@@ -100,6 +101,7 @@ func (c *Client) Claim(offerID types.Hash) (*rpc.ManualTransactionResponse, erro
 	return res, nil
 }
 
+// Refund calls swap_refund
 func (c *Client) Refund(offerID types.Hash) (*rpc.ManualTransactionResponse, error) {
 	const (
 		method = "swap_refund"


### PR DESCRIPTION
new functions:
```
   claim                    manually call claim() in the contract for a given swap. WARNING: This should only be used if the normal swap process fails.
   refund                   manually call refund() in the contract for a given swap. WARNING: This should only be used if the normal swap process fails.
   get-contract-swap-info   Get information about a swap needed to call the contract functions. Returns the contract address, the swap's struct as represented in the contract, and the hash of the swap's struct, which is used as its contract identifier. Note: this is only useful if you plan to manually call the contract functions.
   get-swap-secret          Get the secret for a swap. WARNING: do NOT share this secret with anyone. Doing so may result in a loss of funds. You should not use this function unless you are sure of what you're doing. This function is only useful if you plan to try to manually recover funds.
```

I'm wondering if these should be gated under an "unsafe" or "dev" command/feature, since they shouldn't be used under normal circumstances, especially the manual claim/refund functions.

closes #439
closes #424