### PR TITLE
eth endpoint defaults and error handling

### DIFF
--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -427,7 +427,9 @@ func createEthClient(c *cli.Context, envConf *common.Config) (extethclient.EthCl
 	}
 	if ethEndpoint == "" {
 		// Message is mainnet specific, because we have defaults for dev/stagenet
-		return nil, errors.New("missing ETH endpoint; completely open endpoints are not reliable for swaps")
+		return nil, fmt.Errorf(
+			"--%s flag required, note that open endpoints are unreliable for mainnet swaps", flagEthEndpoint,
+		)
 	}
 
 	var ethPrivKey *ecdsa.PrivateKey

--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -428,7 +428,7 @@ func createEthClient(c *cli.Context, envConf *common.Config) (extethclient.EthCl
 	if ethEndpoint == "" {
 		// Message is mainnet specific, because we have defaults for dev/stagenet
 		return nil, fmt.Errorf(
-			"--%s flag required, note that open endpoints are unreliable for mainnet swaps", flagEthEndpoint,
+			"--%s flag required, note that public endpoints are unreliable for mainnet swaps", flagEthEndpoint,
 		)
 	}
 

--- a/cmd/swapd/main.go
+++ b/cmd/swapd/main.go
@@ -421,9 +421,13 @@ func createMoneroClient(c *cli.Context, envConf *common.Config) (monero.WalletCl
 func createEthClient(c *cli.Context, envConf *common.Config) (extethclient.EthClient, error) {
 	env := envConf.Env
 
-	ethEndpoint := common.DefaultEthEndpoint
-	if c.String(flagEthEndpoint) != "" {
+	ethEndpoint := envConf.EthEndpoint
+	if c.IsSet(flagEthEndpoint) {
 		ethEndpoint = c.String(flagEthEndpoint)
+	}
+	if ethEndpoint == "" {
+		// Message is mainnet specific, because we have defaults for dev/stagenet
+		return nil, errors.New("missing ETH endpoint; completely open endpoints are not reliable for swaps")
 	}
 
 	var ethPrivKey *ecdsa.PrivateKey

--- a/common/config.go
+++ b/common/config.go
@@ -35,8 +35,9 @@ type MoneroNode struct {
 // Config contains constants that are defaults for various environments
 type Config struct {
 	Env             Environment
-	EthereumChainID *big.Int
 	DataDir         string
+	EthereumChainID *big.Int
+	EthEndpoint     string
 	MoneroNodes     []*MoneroNode
 	SwapCreatorAddr ethcommon.Address
 	Bootnodes       []string
@@ -46,8 +47,9 @@ type Config struct {
 func MainnetConfig() *Config {
 	return &Config{
 		Env:             Mainnet,
-		EthereumChainID: big.NewInt(MainnetChainID),
 		DataDir:         path.Join(baseDir, "mainnet"),
+		EthereumChainID: big.NewInt(MainnetChainID),
+		EthEndpoint:     "", // No mainnet default (permissionless URLs are not reliable)
 		MoneroNodes: []*MoneroNode{
 			{
 				Host: "node.sethforprivacy.com",
@@ -87,8 +89,9 @@ func MainnetConfig() *Config {
 func StagenetConfig() *Config {
 	return &Config{
 		Env:             Stagenet,
-		EthereumChainID: big.NewInt(SepoliaChainID),
 		DataDir:         path.Join(baseDir, "stagenet"),
+		EthereumChainID: big.NewInt(SepoliaChainID),
+		EthEndpoint:     "https://rpc.sepolia.org/",
 		MoneroNodes: []*MoneroNode{
 			{
 				Host: "node.sethforprivacy.com",
@@ -123,6 +126,7 @@ func DevelopmentConfig() *Config {
 		Env:             Development,
 		EthereumChainID: big.NewInt(1337),
 		DataDir:         path.Join(baseDir, "dev"),
+		EthEndpoint:     DefaultGanacheEndpoint,
 		MoneroNodes: []*MoneroNode{
 			{
 				Host: "127.0.0.1",

--- a/common/consts.go
+++ b/common/consts.go
@@ -9,7 +9,8 @@ const (
 	DefaultMoneroDaemonMainnetPort  = 18081
 	DefaultMoneroDaemonDevPort      = DefaultMoneroDaemonMainnetPort
 	DefaultMoneroDaemonStagenetPort = 38081
-	DefaultEthEndpoint              = "ws://127.0.0.1:8545"
+	DefaultGanacheEndpoint          = "http://127.0.0.1:8545"
+	DefaultGanacheWSEndpoint        = "ws://127.0.0.1:8545"
 	DefaultSwapdPort                = 5000
 )
 

--- a/daemon/manual_tx_test.go
+++ b/daemon/manual_tx_test.go
@@ -78,7 +78,7 @@ func TestRunSwapDaemon_ManualRefund(t *testing.T) {
 					refundResp, err := acHTTP.Refund(makeResp.OfferID)
 					require.NoError(t, err)
 
-					ec, err := ethclient.Dial(common.DefaultEthEndpoint)
+					ec, err := ethclient.Dial(common.DefaultGanacheEndpoint)
 					require.NoError(t, err)
 
 					t.Log("> Alice got refund response tx:", refundResp.TxHash)

--- a/daemon/test_support.go
+++ b/daemon/test_support.go
@@ -41,7 +41,7 @@ const (
 // for testing
 func CreateTestConf(t *testing.T, ethKey *ecdsa.PrivateKey) *SwapdConfig {
 	ctx := context.Background()
-	ec, err := extethclient.NewEthClient(ctx, common.Development, common.DefaultEthEndpoint, ethKey)
+	ec, err := extethclient.NewEthClient(ctx, common.Development, common.DefaultGanacheEndpoint, ethKey)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ec.Close()

--- a/ethereum/extethclient/test_support.go
+++ b/ethereum/extethclient/test_support.go
@@ -22,7 +22,7 @@ import (
 // wallet key. Cleanup on test completion is handled automatically.
 func CreateTestClient(t *testing.T, ethKey *ecdsa.PrivateKey) EthClient {
 	ctx := context.Background()
-	ec, err := NewEthClient(ctx, common.Development, common.DefaultEthEndpoint, ethKey)
+	ec, err := NewEthClient(ctx, common.Development, common.DefaultGanacheEndpoint, ethKey)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ec.Close()

--- a/protocol/xmrmaker/instance_test.go
+++ b/protocol/xmrmaker/instance_test.go
@@ -113,7 +113,7 @@ func newBackendAndNet(t *testing.T) (backend.Backend, *mockNet) {
 	rdb.EXPECT().PutCounterpartySwapKeys(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	rdb.EXPECT().DeleteSwap(gomock.Any()).Return(nil).AnyTimes()
 
-	extendedEC, err := extethclient.NewEthClient(ctx, env, common.DefaultEthEndpoint, pk)
+	extendedEC, err := extethclient.NewEthClient(ctx, env, common.DefaultGanacheEndpoint, pk)
 	require.NoError(t, err)
 
 	net := new(mockNet)

--- a/scripts/install-lint.sh
+++ b/scripts/install-lint.sh
@@ -2,7 +2,7 @@
 # Installs golangci-lint (https://golangci-lint.run) into the user's personal GOPATH bin directory if it is
 # not there already or if the version does not match the value defined below.
 
-VERSION="v1.51.1"
+VERSION="v1.51.2"
 GOBIN="$(go env GOPATH)/bin"
 LINT="${GOBIN}/golangci-lint"
 

--- a/tests/ganache.go
+++ b/tests/ganache.go
@@ -195,7 +195,7 @@ func GetTakerTestKey(t *testing.T) *ecdsa.PrivateKey {
 // NewEthClient returns a connection to the local ganache instance for unit tests along
 // with its chain ID. The connection is automatically closed when the test completes.
 func NewEthClient(t *testing.T) (*ethclient.Client, *big.Int) {
-	ec, err := ethclient.Dial(common.DefaultEthEndpoint)
+	ec, err := ethclient.Dial(common.DefaultGanacheEndpoint)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ec.Close()


### PR DESCRIPTION
This PR uses our environment config to set the ETH endpoint defaults for dev and stagenet. For mainnet, instead of giving an error because the code cannot connect to the default ganache port on localhost, we tell them that they need to set the endpoint.

Notable change: Our tests are using the http endpoint starting with this PR instead of the ws endpoint.