### PR TITLE
fix: run t1 handler on xmrmaker ongoing swap restart

### DIFF
--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -192,6 +192,13 @@ func (s *swapState) runT1ExpirationHandler() {
 		time.Until(s.t1).Seconds(),
 	)
 
+	if time.Until(s.t2) < 0 {
+		log.Debugf("t2 (%s) has already passed; not starting t1 expiration handler",
+			s.t2.Format(common.TimeFmtSecs),
+		)
+		return
+	}
+
 	waitCtx, waitCtxCancel := context.WithCancel(context.Background())
 	defer waitCtxCancel() // Unblock WaitForTimestamp if still running when we exit
 

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -317,6 +317,8 @@ func newSwapStateFromOngoing(
 	s.pubkeys = sk.PublicKeyPair()
 	s.contractSwapID = ethSwapInfo.SwapID
 	s.contractSwap = ethSwapInfo.Swap
+
+	go s.runT1ExpirationHandler()
 	return s, nil
 }
 


### PR DESCRIPTION
similar issue to the xmrtaker, the timeout handler wasn't being started on restart