### PR TITLE
add prometheus metrics

### DIFF
--- a/rpc/prometheus.go
+++ b/rpc/prometheus.go
@@ -1,0 +1,187 @@
+package rpc
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"golang.org/x/exp/slices"
+
+	"github.com/athanorlabs/atomic-swap/common/types"
+	"github.com/athanorlabs/atomic-swap/protocol/swap"
+)
+
+var namespace = "swapdaemon"
+
+// Metrics represents our prometheus metrics
+type Metrics struct {
+	peersCount            prometheus.GaugeFunc
+	ongoingSwapsCount     prometheus.GaugeFunc
+	pastSwapsSuccessCount prometheus.GaugeFunc
+	pastSwapsRefundCount  prometheus.GaugeFunc
+	pastSwapsAbortCount   prometheus.GaugeFunc
+	offersCount           prometheus.GaugeFunc
+	moneroBalance         prometheus.GaugeFunc
+	ethereumBalance       prometheus.GaugeFunc
+	averageSwapDuration   prometheus.GaugeFunc
+}
+
+func pastSwapsMetric(swapManager SwapManager, status swap.Status, statusLabel string) prometheus.GaugeFunc {
+	return promauto.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Name:        "past_swaps_count",
+			Help:        "The number of past swaps by status",
+			ConstLabels: prometheus.Labels{"status": statusLabel},
+		},
+		func() float64 {
+			pastIDs, err := swapManager.GetPastIDs()
+			if err != nil {
+				return -1
+			}
+
+			var count int
+
+			for _, pastID := range pastIDs {
+				pastSwap, err := swapManager.GetPastSwap(pastID)
+				if err != nil {
+					continue
+				}
+
+				if pastSwap.Status == status {
+					count++
+				}
+			}
+
+			return float64(count)
+		},
+	)
+}
+
+// SetupMetrics creates prometheus metrics and returns a new Metrics
+func SetupMetrics(ctx context.Context, net Net, swapManager SwapManager, pb ProtocolBackend, maker XMRMaker) Metrics {
+	return Metrics{
+		peersCount: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "peers_count",
+				Help:      "The number of connected peers",
+			},
+			func() float64 {
+				peerIDs := []peer.ID{}
+
+				for _, addr := range net.ConnectedPeers() {
+					addrInfo, err := peer.AddrInfoFromString(addr)
+					if err != nil {
+						continue
+					}
+
+					if slices.Index(peerIDs, addrInfo.ID) == -1 {
+						peerIDs = append(peerIDs, addrInfo.ID)
+					}
+				}
+
+				return float64(len(peerIDs))
+			},
+		),
+
+		ongoingSwapsCount: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "ongoing_swaps_count",
+				Help:      "The number of ongoing swaps",
+			},
+			func() float64 {
+				swaps, err := swapManager.GetOngoingSwaps()
+				if err != nil {
+					return float64(-1)
+				}
+				return float64(len(swaps))
+			},
+		),
+
+		pastSwapsSuccessCount: pastSwapsMetric(swapManager, types.CompletedSuccess, "success"),
+		pastSwapsRefundCount:  pastSwapsMetric(swapManager, types.CompletedRefund, "refund"),
+		pastSwapsAbortCount:   pastSwapsMetric(swapManager, types.CompletedAbort, "abort"),
+
+		offersCount: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "owned_offers_count",
+				Help:      "The number of offers",
+			},
+			func() float64 {
+				offers := maker.GetOffers()
+				return float64(len(offers))
+			},
+		),
+
+		moneroBalance: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "balance",
+				Help:        "Balance",
+				ConstLabels: prometheus.Labels{"coin": "xmr"},
+			},
+			func() float64 {
+				_, balanceResp, err := maker.GetMoneroBalance()
+				if err != nil {
+					return float64(-1)
+				}
+				return float64(balanceResp.Balance)
+			},
+		),
+
+		ethereumBalance: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "balance",
+				Help:        "Balance",
+				ConstLabels: prometheus.Labels{"coin": "eth"},
+			},
+			func() float64 {
+				balance, err := pb.ETHClient().Balance(ctx)
+				if err != nil {
+					return float64(-1)
+				}
+				fBalance, err := balance.Decimal().Float64()
+				if err != nil {
+					return float64(-1)
+				}
+				return fBalance
+			},
+		),
+
+		averageSwapDuration: promauto.NewGaugeFunc(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "avg_swap_duration_seconds",
+				Help:      "The average swap duration",
+			},
+			func() float64 {
+				pastIDs, err := swapManager.GetPastIDs()
+				if err != nil {
+					return float64(-1)
+				}
+
+				var (
+					sum   float64
+					count int
+				)
+
+				for _, pastID := range pastIDs {
+					pastSwap, err := swapManager.GetPastSwap(pastID)
+					if err != nil {
+						continue
+					}
+
+					sum += float64(pastSwap.EndTime.Unix() - pastSwap.StartTime.Unix())
+					count++
+				}
+
+				return sum / float64(count)
+			},
+		),
+	}
+}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -134,12 +134,17 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
-	SetupMetrics(serverCtx, cfg.Net, swapManager, cfg.ProtocolBackend, cfg.XMRMaker)
+	reg, err := NewPrometheusRegistry()
+	if err != nil {
+		return nil, err
+	}
+
+	SetupMetrics(serverCtx, reg, cfg.Net, cfg.ProtocolBackend, cfg.XMRMaker)
 
 	r := mux.NewRouter()
 	r.Handle("/", rpcServer)
 	r.Handle("/ws", wsServer)
-	r.Handle("/metrics", promhttp.Handler())
+	r.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 
 	headersOk := handlers.AllowedHeaders([]string{"content-type", "username", "password"})
 	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "OPTIONS"})

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -23,6 +23,8 @@ import (
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common"
 	"github.com/athanorlabs/atomic-swap/common/types"
@@ -132,9 +134,12 @@ func NewServer(cfg *Config) (*Server, error) {
 		return nil, err
 	}
 
+	SetupMetrics(serverCtx, cfg.Net, swapManager, cfg.ProtocolBackend, cfg.XMRMaker)
+
 	r := mux.NewRouter()
 	r.Handle("/", rpcServer)
 	r.Handle("/ws", wsServer)
+	r.Handle("/metrics", promhttp.Handler())
 
 	headersOk := handlers.AllowedHeaders([]string{"content-type", "username", "password"})
 	methodsOk := handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "OPTIONS"})


### PR DESCRIPTION
closes #240

Adds the following prometheus metrics

```shell
# HELP swapdaemon_avg_swap_duration_seconds The average swap duration
# TYPE swapdaemon_avg_swap_duration_seconds gauge
swapdaemon_avg_swap_duration_seconds 18
# HELP swapdaemon_balance Balance
# TYPE swapdaemon_balance gauge
swapdaemon_balance{coin="eth"} 1.0000985748404711e+21
swapdaemon_balance{coin="xmr"} 2.251284930376617e+15
# HELP swapdaemon_ongoing_swaps_count The number of ongoing swaps
# TYPE swapdaemon_ongoing_swaps_count gauge
swapdaemon_ongoing_swaps_count 0
# HELP swapdaemon_owned_offers_count The number of offers
# TYPE swapdaemon_owned_offers_count gauge
swapdaemon_owned_offers_count 0
# HELP swapdaemon_past_swaps_count The number of past swaps by status
# TYPE swapdaemon_past_swaps_count gauge
swapdaemon_past_swaps_count{status="abort"} 0
swapdaemon_past_swaps_count{status="refund"} 0
swapdaemon_past_swaps_count{status="success"} 1
# HELP swapdaemon_peers_count The number of connected peers
# TYPE swapdaemon_peers_count gauge
swapdaemon_peers_count 2
```

The `Metrics` returned by  `SetupMetrics` is currently not used, but could be useful if we add metrics that are not determined at collect time.