### PR TITLE
ensure that the status channel is always initialized

### DIFF
--- a/common/types/offer.go
+++ b/common/types/offer.go
@@ -225,8 +225,6 @@ func (o *Offer) UnmarshalJSON(data []byte) error {
 
 // OfferExtra represents extra data that is passed when an offer is made.
 type OfferExtra struct {
-	StatusCh chan Status `json:"-"`
-
 	// UseRelayer forces the XMR maker to claim using the relayer even when he
 	// has enough funds to make the claim himself. Setting it to false will not
 	// prevent the relayer from being used if there are insufficient ETH funds
@@ -234,31 +232,9 @@ type OfferExtra struct {
 	UseRelayer bool `json:"useRelayer,omitempty"`
 }
 
-// NewStatusChannel creates a status channel using the the correct size
-func NewStatusChannel() chan Status {
-	// The channel size should be large enough to handle the max number of
-	// stages a swap can potentially go through.
-	const statusChSize = 6
-	return make(chan Status, statusChSize)
-}
-
-// NewOfferExtra creates an OfferExtra instance. Use this method, instead of
-// creating objects directly, to ensure that the status channel is initialized
-// correctly.
+// NewOfferExtra creates an OfferExtra instance
 func NewOfferExtra(forceUseRelayer bool) *OfferExtra {
 	return &OfferExtra{
-		StatusCh:   NewStatusChannel(),
 		UseRelayer: forceUseRelayer,
 	}
-}
-
-// UnmarshalJSON provides custom unmarshalling of OfferExtra to ensure that the
-// StatusCh field is always initialized.
-func (o *OfferExtra) UnmarshalJSON(data []byte) error {
-	type _OfferExtra OfferExtra
-	if err := vjson.UnmarshalStruct(data, (*_OfferExtra)(o)); err != nil {
-		return err
-	}
-	o.StatusCh = NewStatusChannel()
-	return nil
 }

--- a/common/types/offer_test.go
+++ b/common/types/offer_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -249,4 +250,19 @@ func TestUnmarshalOffer_VersionTooNew(t *testing.T) {
 	}`, unsupportedVersion)
 	_, err := UnmarshalOffer([]byte(offerJSON))
 	require.ErrorContains(t, err, fmt.Sprintf("offer version %q not supported", unsupportedVersion))
+}
+
+func TestOfferExtra_JSON(t *testing.T) {
+	// Marshal test
+	extra := NewOfferExtra(true)
+	data, err := vjson.MarshalStruct(extra)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"useRelayer":true}`, string(data))
+
+	// Unmarshal test
+	extra = new(OfferExtra)
+	err = json.Unmarshal(data, extra)
+	require.NoError(t, err)
+	require.NotNil(t, extra.StatusCh)
+	require.True(t, extra.UseRelayer)
 }

--- a/common/types/offer_test.go
+++ b/common/types/offer_test.go
@@ -263,6 +263,5 @@ func TestOfferExtra_JSON(t *testing.T) {
 	extra = new(OfferExtra)
 	err = json.Unmarshal(data, extra)
 	require.NoError(t, err)
-	require.NotNil(t, extra.StatusCh)
 	require.True(t, extra.UseRelayer)
 }

--- a/daemon/refund_after_restart_test.go
+++ b/daemon/refund_after_restart_test.go
@@ -108,7 +108,7 @@ func TestXMRNotLockedAndETHRefundedAfterAliceRestarts(t *testing.T) {
 	ctx, cancel = LaunchDaemons(t, 3*time.Minute, aliceConf)
 
 	// This is a bug that we need to recreate Alice's websocket client here. Remove this
-	// codd when we fix https://github.com/AthanorLabs/atomic-swap/issues/353.
+	// code when we fix https://github.com/AthanorLabs/atomic-swap/issues/353.
 	ac, err = wsclient.NewWsClient(clientCtx, fmt.Sprintf("ws://127.0.0.1:%d/ws", aliceConf.RPCPort))
 	require.NoError(t, err)
 

--- a/daemon/refund_after_restart_test.go
+++ b/daemon/refund_after_restart_test.go
@@ -107,6 +107,11 @@ func TestXMRNotLockedAndETHRefundedAfterAliceRestarts(t *testing.T) {
 	t.Logf("daemons stopped, now re-launching Alice's daemon in isolation")
 	ctx, cancel = LaunchDaemons(t, 3*time.Minute, aliceConf)
 
+	// This is a bug that we need to recreate Alice's websocket client here. Remove this
+	// codd when we fix https://github.com/AthanorLabs/atomic-swap/issues/353.
+	ac, err = wsclient.NewWsClient(clientCtx, fmt.Sprintf("ws://127.0.0.1:%d/ws", aliceConf.RPCPort))
+	require.NoError(t, err)
+
 	aliceStatusCh, err = ac.SubscribeSwapStatus(makeResp.OfferID)
 	require.NoError(t, err)
 

--- a/daemon/refund_after_restart_test.go
+++ b/daemon/refund_after_restart_test.go
@@ -1,0 +1,136 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/athanorlabs/atomic-swap/coins"
+	"github.com/athanorlabs/atomic-swap/common/types"
+	"github.com/athanorlabs/atomic-swap/monero"
+	"github.com/athanorlabs/atomic-swap/rpcclient/wsclient"
+	"github.com/athanorlabs/atomic-swap/tests"
+)
+
+func TestXMRNotLockedAndETHRefundedAfterAliceRestarts(t *testing.T) {
+	minXMR := coins.StrToDecimal("1")
+	maxXMR := minXMR
+	exRate := coins.StrToExchangeRate("0.1")
+	providesAmt, err := exRate.ToETH(minXMR)
+	require.NoError(t, err)
+
+	bobConf := CreateTestConf(t, tests.GetMakerTestKey(t))
+	monero.MineMinXMRBalance(t, bobConf.MoneroClient, coins.MoneroToPiconero(maxXMR))
+
+	aliceConf := CreateTestConf(t, tests.GetTakerTestKey(t))
+
+	timeout := 7 * time.Minute
+	ctx, cancel := LaunchDaemons(t, timeout, aliceConf, bobConf)
+
+	// clients use a separate context and will work across server restarts
+	clientCtx := context.Background()
+	bc, err := wsclient.NewWsClient(clientCtx, fmt.Sprintf("ws://127.0.0.1:%d/ws", bobConf.RPCPort))
+	require.NoError(t, err)
+	ac, err := wsclient.NewWsClient(clientCtx, fmt.Sprintf("ws://127.0.0.1:%d/ws", aliceConf.RPCPort))
+	require.NoError(t, err)
+
+	// Bob makes an offer
+	makeResp, bobStatusCh, err := bc.MakeOfferAndSubscribe(minXMR, maxXMR, exRate, types.EthAssetETH, false)
+	require.NoError(t, err)
+
+	// Alice takes the offer
+	aliceStatusCh, err := ac.TakeOfferAndSubscribe(makeResp.PeerID, makeResp.OfferID, providesAmt)
+	require.NoError(t, err)
+
+	var statusWG sync.WaitGroup
+	statusWG.Add(2)
+
+	// Alice shuts down both servers as soon as she locks her ETH
+	go func() {
+		defer statusWG.Done()
+		for {
+			select {
+			case status := <-aliceStatusCh:
+				t.Log("> Alice got status:", status)
+				switch status {
+				case types.ExpectingKeys:
+					continue
+				case types.ETHLocked:
+					cancel() // stop both Alice's and Bob's daemons
+				default:
+					cancel()
+					t.Errorf("Alice should not have reached status=%s", status)
+				}
+			case <-ctx.Done():
+				t.Logf("Alice's context cancelled (expected)")
+				return
+			}
+		}
+	}()
+
+	// Bob is not playing a significant role in this test. His swapd instance is
+	// shut down before he can lock any XMR and we don't bring it back online.
+	go func() {
+		defer statusWG.Done()
+		for {
+			select {
+			case status := <-bobStatusCh:
+				t.Log("> Bob got status:", status)
+				switch status {
+				case types.KeysExchanged:
+					continue
+				default:
+					cancel()
+					t.Errorf("Bob should not have reached status=%s", status)
+				}
+			case <-ctx.Done():
+				t.Logf("Bob's context cancelled (expected)")
+				return
+			}
+		}
+	}()
+
+	statusWG.Wait()
+	if t.Failed() {
+		return
+	}
+
+	// Make sure both servers had time to fully shut down
+	time.Sleep(3 * time.Second)
+
+	// relaunch Alice's daemon
+	t.Logf("daemons stopped, now re-launching Alice's daemon in isolation")
+	ctx, cancel = LaunchDaemons(t, 3*time.Minute, aliceConf)
+
+	aliceStatusCh, err = ac.SubscribeSwapStatus(makeResp.OfferID)
+	require.NoError(t, err)
+
+	// Ensure Alice completes the swap with a refund
+	statusWG.Add(1)
+	go func() {
+		defer statusWG.Done()
+		for {
+			select {
+			case status := <-aliceStatusCh:
+				t.Log("> Alice, after restart, got status:", status)
+				if !status.IsOngoing() {
+					assert.Equal(t, types.CompletedRefund.String(), status.String())
+					return
+				}
+			case <-ctx.Done():
+				// Alice's context has a deadline. If we get here, the context
+				// expired before we got any Refund status update.
+				t.Errorf("Alice's context cancelled before she completed the swap")
+				return
+			}
+		}
+	}()
+
+	statusWG.Wait()
+	// TODO: Add some additional checks here when the rest of the test is working
+}

--- a/daemon/test_support.go
+++ b/daemon/test_support.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"path"
 	"sync"
 	"syscall"
 	"testing"
@@ -87,13 +88,15 @@ func CreateTestBootnode(t *testing.T) (uint16, string) {
 		wg.Wait()
 	})
 
+	dataDir := t.TempDir()
+
 	conf := &bootnode.Config{
 		Env:           common.Development,
 		DataDir:       t.TempDir(),
 		Bootnodes:     nil,
 		P2PListenIP:   "127.0.0.1",
 		Libp2pPort:    0,
-		Libp2pKeyFile: common.DefaultLibp2pKeyFileName,
+		Libp2pKeyFile: path.Join(dataDir, common.DefaultLibp2pKeyFileName),
 		RPCPort:       uint16(rpcPort),
 	}
 

--- a/db/database_test.go
+++ b/db/database_test.go
@@ -331,11 +331,10 @@ func TestDatabase_SwapTable_Update(t *testing.T) {
 
 	// infoB mostly the same as infoA (same ID, importantly), but with
 	// a couple updated fields.
-	infoB := new(swap.Info)
-	*infoB = *infoA
+	infoB, err := infoA.DeepCopy()
+	require.NoError(t, err)
 	infoB.Status = types.CompletedSuccess
-	endTime := time.Now()
-	infoB.EndTime = &endTime
+	infoB.MarkSwapComplete()
 
 	err = db.PutSwap(infoB)
 	require.NoError(t, err)

--- a/db/recovery_db_test.go
+++ b/db/recovery_db_test.go
@@ -91,7 +91,6 @@ func TestRecoveryDB_SwapRelayerInfo(t *testing.T) {
 	res, err := rdb.GetSwapRelayerInfo(offerID)
 	require.NoError(t, err)
 	require.True(t, res.UseRelayer)
-	require.NotNil(t, res.StatusCh)
 }
 
 func TestRecoveryDB_SwapPrivateKey(t *testing.T) {

--- a/db/recovery_db_test.go
+++ b/db/recovery_db_test.go
@@ -83,16 +83,15 @@ func TestRecoveryDB_SwapRelayerInfo(t *testing.T) {
 	rdb := newTestRecoveryDB(t)
 	offerID := types.Hash{5, 6, 7, 8}
 
-	info := &types.OfferExtra{
-		UseRelayer: true,
-	}
+	extra := types.NewOfferExtra(true)
 
-	err := rdb.PutSwapRelayerInfo(offerID, info)
+	err := rdb.PutSwapRelayerInfo(offerID, extra)
 	require.NoError(t, err)
 
 	res, err := rdb.GetSwapRelayerInfo(offerID)
 	require.NoError(t, err)
-	require.Equal(t, info, res)
+	require.True(t, res.UseRelayer)
+	require.NotNil(t, res.StatusCh)
 }
 
 func TestRecoveryDB_SwapPrivateKey(t *testing.T) {
@@ -165,13 +164,11 @@ func TestRecoveryDB_DeleteSwap(t *testing.T) {
 		SwapCreatorAddr: ethcommon.HexToAddress("0xd2b5d6252d0645e4cf4bb547e82a485f527befb7"),
 	}
 
-	info := &types.OfferExtra{
-		UseRelayer: true,
-	}
+	extra := types.NewOfferExtra(true)
 
 	err = rdb.PutContractSwapInfo(offerID, si)
 	require.NoError(t, err)
-	err = rdb.PutSwapRelayerInfo(offerID, info)
+	err = rdb.PutSwapRelayerInfo(offerID, extra)
 	require.NoError(t, err)
 	err = rdb.PutSwapPrivateKey(offerID, kp.SpendKey())
 	require.NoError(t, err)

--- a/db/recovery_db_test.go
+++ b/db/recovery_db_test.go
@@ -90,7 +90,7 @@ func TestRecoveryDB_SwapRelayerInfo(t *testing.T) {
 
 	res, err := rdb.GetSwapRelayerInfo(offerID)
 	require.NoError(t, err)
-	require.True(t, res.UseRelayer)
+	require.Equal(t, extra, res)
 }
 
 func TestRecoveryDB_SwapPrivateKey(t *testing.T) {

--- a/protocol/backend/backend.go
+++ b/protocol/backend/backend.go
@@ -262,7 +262,7 @@ func (b *backend) ClearXMRDepositAddress(offerID types.Hash) {
 // HasOngoingSwapAsTaker returns nil if we have an ongoing swap with the given peer where
 // we're the xmrtaker, otherwise returns an error.
 func (b *backend) HasOngoingSwapAsTaker(remotePeer peer.ID) error {
-	swaps, err := b.swapManager.GetOngoingSwaps()
+	swaps, err := b.swapManager.GetOngoingSwapsSnapshot()
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (b *backend) HandleRelayClaimRequest(
 			return nil, fmt.Errorf("cannot relay taker-specific claim request; no ongoing swap for swap %s", *request.OfferID)
 		}
 
-		info, err := b.swapManager.GetOngoingSwap(*request.OfferID)
+		info, err := b.swapManager.GetOngoingSwapSnapshot(*request.OfferID)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/claim_monero.go
+++ b/protocol/claim_monero.go
@@ -24,6 +24,7 @@ var (
 // SwapManager is the subset of the swap.Manager interface needed by ClaimMonero
 type SwapManager interface {
 	WriteSwapToDB(info *swap.Info) error
+	PushNewStatus(offerID types.Hash, status types.Status)
 }
 
 // GetClaimKeypair returns the private key pair required for a monero claim.
@@ -103,6 +104,7 @@ func ClaimMonero(
 // setSweepStatus sets the swap's status as `SweepingXMR` and writes it to the db.
 func setSweepStatus(info *swap.Info, sm SwapManager) error {
 	info.SetStatus(types.SweepingXMR)
+	sm.PushNewStatus(info.OfferID, types.SweepingXMR)
 	err := sm.WriteSwapToDB(info)
 	if err != nil {
 		return fmt.Errorf("failed to write swap to db: %w", err)

--- a/protocol/claim_monero_test.go
+++ b/protocol/claim_monero_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common"
+	"github.com/athanorlabs/atomic-swap/common/types"
 	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
 	"github.com/athanorlabs/atomic-swap/monero"
 	"github.com/athanorlabs/atomic-swap/protocol/swap"
@@ -27,6 +28,9 @@ type mockSwapManager struct{}
 
 func (*mockSwapManager) WriteSwapToDB(info *swap.Info) error {
 	return nil
+}
+
+func (*mockSwapManager) PushNewStatus(_ types.Hash, _ types.Status) {
 }
 
 func TestClaimMonero_NoTransferBack(t *testing.T) {

--- a/protocol/swap/manager_test.go
+++ b/protocol/swap/manager_test.go
@@ -38,7 +38,7 @@ func TestNewManager(t *testing.T) {
 		types.EthAssetETH,
 		types.ExpectingKeys,
 		100,
-		nil,
+		types.NewStatusChannel(),
 	)
 	db.EXPECT().PutSwap(infoA)
 	err = m.AddSwap(infoA)
@@ -54,7 +54,7 @@ func TestNewManager(t *testing.T) {
 		types.EthAssetETH,
 		types.CompletedSuccess,
 		100,
-		nil,
+		types.NewStatusChannel(),
 	)
 	db.EXPECT().PutSwap(infoB)
 	err = m.AddSwap(infoB)
@@ -88,7 +88,7 @@ func TestManager_AddSwap_Ongoing(t *testing.T) {
 		types.EthAssetETH,
 		types.ExpectingKeys,
 		100,
-		nil,
+		types.NewStatusChannel(),
 	)
 
 	db.EXPECT().PutSwap(info)

--- a/protocol/swap/status_manager.go
+++ b/protocol/swap/status_manager.go
@@ -56,6 +56,11 @@ func (sm *statusManager) PushNewStatus(offerID types.Hash, status types.Status) 
 	// via the channel since they already have a reference to it. New
 	// subscribers will get the final status from the past swaps map.
 	if !status.IsOngoing() {
+		// We grabbed the status channel before calling IsOngoing to avoid a
+		// race condition where the status becomes complete after the check, but
+		// before we grab a reference to the channel. If the status was complete
+		// before we grabbed the channel, we created a new channel, which we
+		// remove below.
 		sm.DeleteStatusChan(offerID)
 	}
 }

--- a/protocol/swap/status_manager.go
+++ b/protocol/swap/status_manager.go
@@ -1,0 +1,63 @@
+package swap
+
+import (
+	"sync"
+
+	"github.com/athanorlabs/atomic-swap/common/types"
+)
+
+// statusManager provides lookup for the status channels. Status channels are
+// ephemeral between runs of swapd.
+type statusManager struct {
+	mu             sync.Mutex
+	statusChannels map[types.Hash]chan Status
+}
+
+func newStatusManager() *statusManager {
+	return &statusManager{
+		mu:             sync.Mutex{},
+		statusChannels: make(map[types.Hash]chan Status),
+	}
+}
+
+// getStatusChan returns any existing status channel or a new status channel for
+// reading or writing.
+func (sm *statusManager) getStatusChan(offerID types.Hash) chan Status {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	_, ok := sm.statusChannels[offerID]
+	if !ok {
+		sm.statusChannels[offerID] = newStatusChannel()
+	}
+
+	return sm.statusChannels[offerID]
+}
+
+// GetStatusChan returns any existing status channel or a new status channel for
+// reading only.
+func (sm *statusManager) GetStatusChan(offerID types.Hash) <-chan Status {
+	return sm.getStatusChan(offerID)
+}
+
+// DeleteStatusChan deletes any status channel associated with the offer ID.
+func (sm *statusManager) DeleteStatusChan(offerID types.Hash) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	delete(sm.statusChannels, offerID)
+}
+
+// PushNewStatus adds a new status to the offer ID's channel
+func (sm *statusManager) PushNewStatus(offerID types.Hash, status types.Status) {
+	sm.getStatusChan(offerID) <- status
+}
+
+// newStatusChannel creates a status channel using the the correct size
+func newStatusChannel() chan Status {
+	// The channel size should be large enough to handle the max number of
+	// stages a swap can potentially go through.
+	const statusChSize = 6
+	ch := make(chan Status, statusChSize)
+	return ch
+}

--- a/protocol/swap/status_manager.go
+++ b/protocol/swap/status_manager.go
@@ -50,7 +50,14 @@ func (sm *statusManager) DeleteStatusChan(offerID types.Hash) {
 
 // PushNewStatus adds a new status to the offer ID's channel
 func (sm *statusManager) PushNewStatus(offerID types.Hash, status types.Status) {
-	sm.getStatusChan(offerID) <- status
+	ch := sm.getStatusChan(offerID)
+	ch <- status
+	// If the status is not ongoing, existing subscribers will get the status
+	// via the channel since they already have a reference to it. New
+	// subscribers will get the final status from the past swaps map.
+	if !status.IsOngoing() {
+		sm.DeleteStatusChan(offerID)
+	}
 }
 
 // newStatusChannel creates a status channel using the the correct size

--- a/protocol/swap/status_manager_test.go
+++ b/protocol/swap/status_manager_test.go
@@ -1,0 +1,26 @@
+package swap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/athanorlabs/atomic-swap/common/types"
+)
+
+func TestStatusManager(t *testing.T) {
+	offerID1 := types.Hash{0x1}
+
+	statusMgr := newStatusManager()
+	ch1 := statusMgr.GetStatusChan(offerID1)
+	ch2 := statusMgr.GetStatusChan(offerID1)
+	require.Equal(t, ch1, ch2)
+
+	statusMgr.PushNewStatus(offerID1, types.CompletedSuccess)
+	status := <-ch1
+	require.Equal(t, types.CompletedSuccess, status)
+
+	statusMgr.DeleteStatusChan(offerID1)
+	ch3 := statusMgr.GetStatusChan(offerID1)
+	require.NotEqual(t, ch1, ch3)
+}

--- a/protocol/swap/swap_manager.go
+++ b/protocol/swap/swap_manager.go
@@ -173,11 +173,6 @@ func (m *manager) GetOngoingSwapSnapshot(offerID types.Hash) (*Info, error) {
 		return nil, errNoSwapWithOfferID
 	}
 
-	// We have the read lock above when making this copy, but the swapState
-	// instances don't use that lock when they modify the same Info structure
-	// from a different go process. At some point we should update the swapState
-	// instances to make all changes to their ongoing Info structure via this
-	// manager.
 	sc, err := s.DeepCopy()
 	if err != nil {
 		return nil, err

--- a/protocol/swap/swap_manager.go
+++ b/protocol/swap/swap_manager.go
@@ -196,8 +196,8 @@ func (m *manager) GetOngoingSwapOfferIDs() ([]*types.Hash, error) {
 }
 
 // GetOngoingSwapsSnapshot returns a copy of all ongoing swaps. If you need to
-// modify the result or read from its status channel, call `GetOngoingSwap` on
-// the offerID to get the "live" Info object.
+// modify the result, call `GetOngoingSwap` on the offerID to get the "live"
+// Info object.
 func (m *manager) GetOngoingSwapsSnapshot() ([]*Info, error) {
 	m.RLock()
 	defer m.RUnlock()

--- a/protocol/swap/swap_manager.go
+++ b/protocol/swap/swap_manager.go
@@ -162,9 +162,8 @@ func (m *manager) GetOngoingSwap(offerID types.Hash) (*Info, error) {
 	return s, nil
 }
 
-// GetOngoingSwapSnapshot returns the ongoing swap's *Info, if there is one. The
-// returned Info structure of an active swap can be modified as the swap's state
-// changes and should only be accessed by a single go process.
+// GetOngoingSwapSnapshot returns a copy of the ongoing swap's Info, if the
+// offerID has an ongoing swap.
 func (m *manager) GetOngoingSwapSnapshot(offerID types.Hash) (*Info, error) {
 	m.RLock()
 	defer m.RUnlock()
@@ -174,6 +173,11 @@ func (m *manager) GetOngoingSwapSnapshot(offerID types.Hash) (*Info, error) {
 		return nil, errNoSwapWithOfferID
 	}
 
+	// We have the read lock above when making this copy, but the swapState
+	// instances don't use that lock when they modify the same Info structure
+	// from a different go process. At some point we should update the swapState
+	// instances to make all changes to their ongoing Info structure via this
+	// manager.
 	sc, err := s.DeepCopy()
 	if err != nil {
 		return nil, err

--- a/protocol/swap/swap_manager.go
+++ b/protocol/swap/swap_manager.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ChainSafe/chaindb"
 )
 
-var errNoSwapWithID = errors.New("unable to find swap with given ID")
+var errNoSwapWithOfferID = errors.New("unable to find swap with given offer ID")
 
 // Manager tracks current and past swaps.
 type Manager interface {
@@ -23,10 +23,15 @@ type Manager interface {
 	WriteSwapToDB(info *Info) error
 	GetPastIDs() ([]types.Hash, error)
 	GetPastSwap(types.Hash) (*Info, error)
-	GetOngoingSwap(types.Hash) (Info, error)
-	GetOngoingSwaps() ([]*Info, error)
+	GetOngoingSwap(hash types.Hash) (*Info, error)
+	GetOngoingSwapSnapshot(types.Hash) (*Info, error)
+	GetOngoingSwapOfferIDs() ([]*types.Hash, error)
+	GetOngoingSwapsSnapshot() ([]*Info, error)
 	CompleteOngoingSwap(info *Info) error
 	HasOngoingSwap(types.Hash) bool
+	GetStatusChan(offerID types.Hash) <-chan types.Status
+	DeleteStatusChan(offerID types.Hash)
+	PushNewStatus(offerID types.Hash, status types.Status)
 }
 
 // manager implements Manager.
@@ -38,6 +43,7 @@ type manager struct {
 	sync.RWMutex
 	ongoing map[types.Hash]*Info
 	past    map[types.Hash]*Info
+	*statusManager
 }
 
 var _ Manager = (*manager)(nil)
@@ -62,9 +68,10 @@ func NewManager(db Database) (Manager, error) {
 	}
 
 	return &manager{
-		db:      db,
-		ongoing: ongoing,
-		past:    make(map[types.Hash]*Info),
+		db:            db,
+		ongoing:       ongoing,
+		past:          make(map[types.Hash]*Info),
+		statusManager: newStatusManager(),
 	}, nil
 }
 
@@ -140,30 +147,71 @@ func (m *manager) GetPastSwap(id types.Hash) (*Info, error) {
 	return s, nil
 }
 
-// GetOngoingSwap returns the ongoing swap's *Info, if there is one.
-func (m *manager) GetOngoingSwap(id types.Hash) (Info, error) {
+// GetOngoingSwap returns the ongoing swap's *Info, if there is one. The
+// returned Info structure of an active swap can be modified as the swap's state
+// changes and should only be read or written by a single go process.
+func (m *manager) GetOngoingSwap(offerID types.Hash) (*Info, error) {
 	m.RLock()
 	defer m.RUnlock()
-	s, has := m.ongoing[id]
+
+	s, has := m.ongoing[offerID]
 	if !has {
-		return Info{}, errNoSwapWithID
+		return nil, errNoSwapWithOfferID
 	}
 
-	return *s, nil
+	return s, nil
 }
 
-// GetOngoingSwaps returns all ongoing swaps.
-func (m *manager) GetOngoingSwaps() ([]*Info, error) {
+// GetOngoingSwapSnapshot returns the ongoing swap's *Info, if there is one. The
+// returned Info structure of an active swap can be modified as the swap's state
+// changes and should only be accessed by a single go process.
+func (m *manager) GetOngoingSwapSnapshot(offerID types.Hash) (*Info, error) {
 	m.RLock()
 	defer m.RUnlock()
-	swaps := make([]*Info, len(m.ongoing))
-	i := 0
-	for _, s := range m.ongoing {
-		sCopy := new(Info)
-		*sCopy = *s
-		swaps[i] = sCopy
-		i++
+
+	s, has := m.ongoing[offerID]
+	if !has {
+		return nil, errNoSwapWithOfferID
 	}
+
+	sc, err := s.DeepCopy()
+	if err != nil {
+		return nil, err
+	}
+
+	return sc, nil
+}
+
+// GetOngoingSwapOfferIDs returns a list of the offer IDs of all ongoing
+// swaps.
+func (m *manager) GetOngoingSwapOfferIDs() ([]*types.Hash, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	offerIDs := make([]*types.Hash, 0, len(m.ongoing))
+	for _, s := range m.ongoing {
+		offerIDs = append(offerIDs, &s.OfferID)
+	}
+
+	return offerIDs, nil
+}
+
+// GetOngoingSwapsSnapshot returns a copy of all ongoing swaps. If you need to
+// modify the result or read from its status channel, call `GetOngoingSwap` on
+// the offerID to get the "live" Info object.
+func (m *manager) GetOngoingSwapsSnapshot() ([]*Info, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	swaps := make([]*Info, 0, len(m.ongoing))
+	for _, s := range m.ongoing {
+		sc, err := s.DeepCopy()
+		if err != nil {
+			return nil, err
+		}
+		swaps = append(swaps, sc)
+	}
+
 	return swaps, nil
 }
 
@@ -171,9 +219,10 @@ func (m *manager) GetOngoingSwaps() ([]*Info, error) {
 func (m *manager) CompleteOngoingSwap(info *Info) error {
 	m.Lock()
 	defer m.Unlock()
+
 	_, has := m.ongoing[info.OfferID]
 	if !has {
-		return errNoSwapWithID
+		return errNoSwapWithOfferID
 	}
 
 	now := time.Now()
@@ -190,6 +239,7 @@ func (m *manager) CompleteOngoingSwap(info *Info) error {
 func (m *manager) HasOngoingSwap(id types.Hash) bool {
 	m.RLock()
 	defer m.RUnlock()
+
 	_, has := m.ongoing[id]
 	return has
 }
@@ -197,7 +247,7 @@ func (m *manager) HasOngoingSwap(id types.Hash) bool {
 func (m *manager) getSwapFromDB(id types.Hash) (*Info, error) {
 	s, err := m.db.GetSwap(id)
 	if errors.Is(chaindb.ErrKeyNotFound, err) {
-		return nil, errNoSwapWithID
+		return nil, errNoSwapWithOfferID
 	}
 	if err != nil {
 		return nil, err

--- a/protocol/swap/swap_manager_test.go
+++ b/protocol/swap/swap_manager_test.go
@@ -38,7 +38,6 @@ func TestNewManager(t *testing.T) {
 		types.EthAssetETH,
 		types.ExpectingKeys,
 		100,
-		types.NewStatusChannel(),
 	)
 	db.EXPECT().PutSwap(infoA)
 	err = m.AddSwap(infoA)
@@ -54,7 +53,6 @@ func TestNewManager(t *testing.T) {
 		types.EthAssetETH,
 		types.CompletedSuccess,
 		100,
-		types.NewStatusChannel(),
 	)
 	db.EXPECT().PutSwap(infoB)
 	err = m.AddSwap(infoB)
@@ -88,7 +86,6 @@ func TestManager_AddSwap_Ongoing(t *testing.T) {
 		types.EthAssetETH,
 		types.ExpectingKeys,
 		100,
-		types.NewStatusChannel(),
 	)
 
 	db.EXPECT().PutSwap(info)
@@ -100,7 +97,7 @@ func TestManager_AddSwap_Ongoing(t *testing.T) {
 
 	s, err := m.GetOngoingSwap(types.Hash{})
 	require.NoError(t, err)
-	require.Equal(t, info, &s)
+	require.Equal(t, info, s)
 	require.NotNil(t, m.ongoing)
 
 	db.EXPECT().PutSwap(info)

--- a/protocol/swap/types.go
+++ b/protocol/swap/types.go
@@ -114,7 +114,7 @@ func UnmarshalInfo(jsonData []byte) (*Info, error) {
 }
 
 // UnmarshalJSON deserializes a JSON Info struct, checking the version for
-// compatibility and ensuring the status channel is always initialized.
+// compatibility.
 func (i *Info) UnmarshalJSON(jsonData []byte) error {
 	iv := struct {
 		Version *semver.Version `json:"version"`

--- a/protocol/swap/types_test.go
+++ b/protocol/swap/types_test.go
@@ -32,7 +32,7 @@ func Test_InfoMarshal(t *testing.T) {
 		types.EthAssetETH,
 		types.CompletedSuccess,
 		200,
-		make(chan types.Status),
+		types.NewStatusChannel(),
 	)
 	err := info.StartTime.UnmarshalJSON([]byte("\"2023-02-20T17:29:43.471020297-05:00\""))
 	require.NoError(t, err)

--- a/protocol/swap/types_test.go
+++ b/protocol/swap/types_test.go
@@ -32,7 +32,6 @@ func Test_InfoMarshal(t *testing.T) {
 		types.EthAssetETH,
 		types.CompletedSuccess,
 		200,
-		types.NewStatusChannel(),
 	)
 	err := info.StartTime.UnmarshalJSON([]byte("\"2023-02-20T17:29:43.471020297-05:00\""))
 	require.NoError(t, err)

--- a/protocol/xmrmaker/checks.go
+++ b/protocol/xmrmaker/checks.go
@@ -134,6 +134,5 @@ func (s *swapState) checkAndSetTimeouts(t1, t2 *big.Int) error {
 func (s *swapState) setTimeouts(t1, t2 *big.Int) {
 	s.t1 = time.Unix(t1.Int64(), 0)
 	s.t2 = time.Unix(t2.Int64(), 0)
-	s.info.Timeout1 = &s.t1
-	s.info.Timeout2 = &s.t2
+	s.info.SetTimeouts(&s.t1, &s.t2)
 }

--- a/protocol/xmrmaker/event_test.go
+++ b/protocol/xmrmaker/event_test.go
@@ -36,7 +36,7 @@ func TestSwapState_handleEvent_EventContractReady(t *testing.T) {
 
 	// runContractEventWatcher will trigger EventContractReady,
 	// which will then set the next expected event to EventExit.
-	for status := range s.info.StatusCh() {
+	for status := range s.SwapManager().GetStatusChan(s.OfferID()) {
 		if !status.IsOngoing() {
 			break
 		}

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -178,7 +178,7 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 	if err != nil {
 		// we can ignore the error; if the key doesn't exist,
 		// then no relayer was set for this swap.
-		relayerInfo = &types.OfferExtra{}
+		relayerInfo = types.NewOfferExtra(false)
 	}
 
 	ss, err := newSwapStateFromOngoing(

--- a/protocol/xmrmaker/instance.go
+++ b/protocol/xmrmaker/instance.go
@@ -57,7 +57,7 @@ type Config struct {
 // NewInstance returns a new *xmrmaker.Instance.
 // It accepts an endpoint to a monero-wallet-rpc instance where account 0 contains XMRMaker's XMR.
 func NewInstance(cfg *Config) (*Instance, error) {
-	om, err := offers.NewManager(cfg.DataDir, cfg.Database, cfg.Backend.SwapManager())
+	om, err := offers.NewManager(cfg.DataDir, cfg.Database)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -52,7 +52,7 @@ func (s *swapState) HandleProtocolMessage(msg common.Message) error {
 
 func (s *swapState) clearNextExpectedEvent(status types.Status) {
 	s.nextExpectedEvent = EventNoneType
-	s.UpdateStatus(status)
+	s.updateStatus(status)
 }
 
 func (s *swapState) setNextExpectedEvent(event EventType) error {
@@ -72,7 +72,7 @@ func (s *swapState) setNextExpectedEvent(event EventType) error {
 		panic("status corresponding to event cannot be UnknownStatus")
 	}
 
-	s.UpdateStatus(status)
+	s.updateStatus(status)
 	err := s.Backend.SwapManager().WriteSwapToDB(s.info)
 	if err != nil {
 		return err

--- a/protocol/xmrmaker/message_handler.go
+++ b/protocol/xmrmaker/message_handler.go
@@ -52,7 +52,7 @@ func (s *swapState) HandleProtocolMessage(msg common.Message) error {
 
 func (s *swapState) clearNextExpectedEvent(status types.Status) {
 	s.nextExpectedEvent = EventNoneType
-	s.info.SetStatus(status)
+	s.UpdateStatus(status)
 }
 
 func (s *swapState) setNextExpectedEvent(event EventType) error {
@@ -72,7 +72,7 @@ func (s *swapState) setNextExpectedEvent(event EventType) error {
 		panic("status corresponding to event cannot be UnknownStatus")
 	}
 
-	s.info.SetStatus(status)
+	s.UpdateStatus(status)
 	err := s.Backend.SwapManager().WriteSwapToDB(s.info)
 	if err != nil {
 		return err

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/ChainSafe/chaindb"
 
-	"github.com/athanorlabs/atomic-swap/common/types"
-	"github.com/athanorlabs/atomic-swap/protocol/swap"
-
 	logging "github.com/ipfs/go-log"
+
+	"github.com/athanorlabs/atomic-swap/common/types"
 )
 
 var (
@@ -37,7 +36,7 @@ type offerWithExtra struct {
 
 // NewManager creates a new offer manager. The passed in dataDir is the
 // directory where the recovery file is for each individual swap is stored.
-func NewManager(dataDir string, db Database, swapManager swap.Manager) (*Manager, error) {
+func NewManager(dataDir string, db Database) (*Manager, error) {
 	log.Infof("loading any saved offers from db")
 	// load offers from the database, if there are any
 	savedOffers, err := db.GetAllOffers()

--- a/protocol/xmrmaker/offers/offer_manager.go
+++ b/protocol/xmrmaker/offers/offer_manager.go
@@ -15,8 +15,6 @@ import (
 	logging "github.com/ipfs/go-log"
 )
 
-const statusChSize = 6 // the max number of stages a swap can potentially go through
-
 var (
 	log = logging.Logger("offers")
 
@@ -49,9 +47,7 @@ func NewManager(dataDir string, db Database) (*Manager, error) {
 	offers := make(map[types.Hash]*offerWithExtra)
 
 	for _, offer := range savedOffers {
-		extra := &types.OfferExtra{
-			StatusCh: make(chan types.Status, statusChSize),
-		}
+		extra := types.NewOfferExtra(false)
 
 		offers[offer.ID] = &offerWithExtra{
 			offer: offer,
@@ -101,10 +97,7 @@ func (m *Manager) AddOffer(
 		return nil, err
 	}
 
-	extra := &types.OfferExtra{
-		StatusCh:   make(chan types.Status, statusChSize),
-		UseRelayer: useRelayer,
-	}
+	extra := types.NewOfferExtra(useRelayer)
 
 	m.offers[id] = &offerWithExtra{
 		offer: offer,

--- a/protocol/xmrmaker/offers/offer_manager_test.go
+++ b/protocol/xmrmaker/offers/offer_manager_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/athanorlabs/atomic-swap/coins"
 	"github.com/athanorlabs/atomic-swap/common/types"
 	"github.com/athanorlabs/atomic-swap/db"
-	"github.com/athanorlabs/atomic-swap/protocol/swap"
 )
 
 func Test_Manager(t *testing.T) {
@@ -29,10 +28,7 @@ func Test_Manager(t *testing.T) {
 	db.EXPECT().ClearAllOffers()
 
 	infoDir := t.TempDir()
-	swapManager, err := swap.NewManager(swap.NewMockDatabase(gomock.NewController(t)))
-	require.NoError(t, err)
-
-	mgr, err := NewManager(infoDir, db, swapManager)
+	mgr, err := NewManager(infoDir, db)
 	require.NoError(t, err)
 
 	for i := 0; i < numAdd; i++ {
@@ -80,10 +76,7 @@ func Test_Manager_NoErrorDeletingOfferNotOnDisk(t *testing.T) {
 	testDB, err := db.NewDatabase(&chaindb.Config{DataDir: dataDir})
 	require.NoError(t, err)
 
-	swapManager, err := swap.NewManager(testDB)
-	require.NoError(t, err)
-
-	mgr, err := NewManager(dataDir, testDB, swapManager)
+	mgr, err := NewManager(dataDir, testDB)
 	require.NoError(t, err)
 
 	offer := types.NewOffer(
@@ -107,8 +100,7 @@ func Test_Manager_NoErrorDeletingOfferNotOnDisk(t *testing.T) {
 	// because the code above did not succeed in deleting it from disk.
 	testDB, err = db.NewDatabase(&chaindb.Config{DataDir: dataDir})
 	require.NoError(t, err)
-
-	mgr, err = NewManager(dataDir, testDB, swapManager)
+	mgr, err = NewManager(dataDir, testDB)
 	require.NoError(t, err)
 
 	// Verify that the entry still exists after restart

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -112,9 +112,6 @@ func newSwapStateFromStart(
 	// and we'll send our own after this function returns.
 	// see HandleInitiateMessage().
 	stage := types.KeysExchanged
-	if offerExtra.StatusCh == nil {
-		offerExtra.StatusCh = make(chan types.Status, 7)
-	}
 
 	if offerExtra.UseRelayer {
 		if err := b.RecoveryDB().PutSwapRelayerInfo(offer.ID, offerExtra); err != nil {

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -450,7 +450,7 @@ func (s *swapState) SendKeysMessage() common.Message {
 	}
 }
 
-func (s *swapState) UpdateStatus(status types.Status) {
+func (s *swapState) updateStatus(status types.Status) {
 	s.info.SetStatus(status)
 	s.SwapManager().PushNewStatus(s.OfferID(), status)
 }

--- a/protocol/xmrmaker/swap_state.go
+++ b/protocol/xmrmaker/swap_state.go
@@ -143,7 +143,6 @@ func newSwapStateFromStart(
 		offer.EthAsset,
 		stage,
 		moneroStartHeight,
-		offerExtra.StatusCh,
 	)
 
 	if err = b.SwapManager().AddSwap(info); err != nil {
@@ -168,7 +167,8 @@ func newSwapStateFromStart(
 		return nil, err
 	}
 
-	offerExtra.StatusCh <- stage
+	s.SwapManager().PushNewStatus(offer.ID, stage)
+
 	return s, nil
 }
 
@@ -244,6 +244,7 @@ func checkIfAlreadyClaimed(
 func completeSwap(info *swap.Info, b backend.Backend, om *offers.Manager) error {
 	// set swap to completed
 	info.SetStatus(types.CompletedSuccess)
+	b.SwapManager().PushNewStatus(info.OfferID, types.CompletedSuccess)
 	err := b.SwapManager().CompleteOngoingSwap(info)
 	if err != nil {
 		return fmt.Errorf("failed to mark swap %s as completed: %s", info.OfferID, err)
@@ -447,6 +448,11 @@ func (s *swapState) SendKeysMessage() common.Message {
 		Secp256k1PublicKey: s.secp256k1Pub,
 		EthAddress:         s.ETHClient().Address(),
 	}
+}
+
+func (s *swapState) UpdateStatus(status types.Status) {
+	s.info.SetStatus(status)
+	s.SwapManager().PushNewStatus(s.OfferID(), status)
 }
 
 // ExpectedAmount returns the amount received, or expected to be received, at the end of the swap

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -419,7 +419,7 @@ func TestSwapState_Exit_Success(t *testing.T) {
 	max := coins.StrToDecimal("0.2")
 	rate := coins.ToExchangeRate(coins.StrToDecimal("0.1"))
 	s.offer = types.NewOffer(coins.ProvidesXMR, min, max, rate, types.EthAssetETH)
-	s.UpdateStatus(types.CompletedSuccess)
+	s.updateStatus(types.CompletedSuccess)
 	err := s.Exit()
 	require.NoError(t, err)
 
@@ -442,7 +442,7 @@ func TestSwapState_Exit_Refunded(t *testing.T) {
 	_, err := b.MakeOffer(s.offer, false)
 	require.NoError(t, err)
 
-	s.UpdateStatus(types.CompletedRefund)
+	s.updateStatus(types.CompletedRefund)
 	err = s.Exit()
 	require.NoError(t, err)
 

--- a/protocol/xmrmaker/swap_state_test.go
+++ b/protocol/xmrmaker/swap_state_test.go
@@ -44,7 +44,7 @@ func newTestSwapStateAndDB(t *testing.T) (*Instance, *swapState, *offers.MockDat
 		xmrmaker.backend,
 		testPeerID,
 		types.NewOffer("", new(apd.Decimal), new(apd.Decimal), new(coins.ExchangeRate), types.EthAssetETH),
-		&types.OfferExtra{},
+		types.NewOfferExtra(false),
 		xmrmaker.offerManager,
 		coins.MoneroToPiconero(coins.StrToDecimal("0.05")),
 		desiredAmount,

--- a/protocol/xmrtaker/instance.go
+++ b/protocol/xmrtaker/instance.go
@@ -64,12 +64,17 @@ func NewInstance(cfg *Config) (*Instance, error) {
 }
 
 func (inst *Instance) checkForOngoingSwaps() error {
-	swaps, err := inst.backend.SwapManager().GetOngoingSwaps()
+	ongoingIDs, err := inst.backend.SwapManager().GetOngoingSwapOfferIDs()
 	if err != nil {
 		return err
 	}
 
-	for _, s := range swaps {
+	for _, offerID := range ongoingIDs {
+		s, err := inst.backend.SwapManager().GetOngoingSwap(*offerID)
+		if err != nil {
+			return err
+		}
+
 		if s.Provides != coins.ProvidesETH {
 			continue
 		}
@@ -171,7 +176,7 @@ func (inst *Instance) createOngoingSwap(s *swap.Info) error {
 }
 
 // completeSwap is called in the case where we find an ongoing swap in the db on startup,
-// and the swap already has the counterpary's swap secret stored.
+// and the swap already has the counterparty's swap secret stored.
 // In this case, we simply claim the XMR, as we have both secrets required.
 // It's unlikely for this case to ever be hit, unless the daemon was shut down in-between
 // us finding the counterparty's secret and claiming the XMR.

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -40,7 +40,7 @@ func (s *swapState) HandleProtocolMessage(msg common.Message) error {
 
 func (s *swapState) clearNextExpectedEvent(status types.Status) {
 	s.nextExpectedEvent = EventNoneType
-	s.UpdateStatus(status)
+	s.updateStatus(status)
 }
 
 func (s *swapState) setNextExpectedEvent(event EventType) error {
@@ -61,7 +61,7 @@ func (s *swapState) setNextExpectedEvent(event EventType) error {
 	}
 
 	log.Debugf("setting status to %s", status)
-	s.UpdateStatus(status)
+	s.updateStatus(status)
 	return s.Backend.SwapManager().WriteSwapToDB(s.info)
 }
 

--- a/protocol/xmrtaker/message_handler.go
+++ b/protocol/xmrtaker/message_handler.go
@@ -40,7 +40,7 @@ func (s *swapState) HandleProtocolMessage(msg common.Message) error {
 
 func (s *swapState) clearNextExpectedEvent(status types.Status) {
 	s.nextExpectedEvent = EventNoneType
-	s.info.SetStatus(status)
+	s.UpdateStatus(status)
 }
 
 func (s *swapState) setNextExpectedEvent(event EventType) error {
@@ -61,7 +61,7 @@ func (s *swapState) setNextExpectedEvent(event EventType) error {
 	}
 
 	log.Debugf("setting status to %s", status)
-	s.info.SetStatus(status)
+	s.UpdateStatus(status)
 	return s.Backend.SwapManager().WriteSwapToDB(s.info)
 }
 

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -104,7 +104,7 @@ func newSwapStateFromStart(
 	ethAsset types.EthAsset,
 ) (*swapState, error) {
 	stage := types.ExpectingKeys
-	statusCh := make(chan types.Status, 16)
+	statusCh := types.NewStatusChannel()
 
 	moneroStartNumber, err := b.XMRClient().GetHeight()
 	if err != nil {

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -317,7 +317,7 @@ func (s *swapState) SendKeysMessage() common.Message {
 	}
 }
 
-func (s *swapState) UpdateStatus(status types.Status) {
+func (s *swapState) updateStatus(status types.Status) {
 	s.info.SetStatus(status)
 	s.SwapManager().PushNewStatus(s.OfferID(), status)
 }

--- a/protocol/xmrtaker/swap_state.go
+++ b/protocol/xmrtaker/swap_state.go
@@ -104,7 +104,6 @@ func newSwapStateFromStart(
 	ethAsset types.EthAsset,
 ) (*swapState, error) {
 	stage := types.ExpectingKeys
-	statusCh := types.NewStatusChannel()
 
 	moneroStartNumber, err := b.XMRClient().GetHeight()
 	if err != nil {
@@ -136,7 +135,6 @@ func newSwapStateFromStart(
 		ethAsset,
 		stage,
 		moneroStartNumber,
-		statusCh,
 	)
 	if err = b.SwapManager().AddSwap(info); err != nil {
 		return nil, err
@@ -157,7 +155,8 @@ func newSwapStateFromStart(
 		return nil, err
 	}
 
-	statusCh <- stage
+	s.SwapManager().PushNewStatus(offerID, stage)
+
 	return s, nil
 }
 
@@ -316,6 +315,11 @@ func (s *swapState) SendKeysMessage() common.Message {
 		DLEqProof:          s.dleqProof.Proof(),
 		Secp256k1PublicKey: s.secp256k1Pub,
 	}
+}
+
+func (s *swapState) UpdateStatus(status types.Status) {
+	s.info.SetStatus(status)
+	s.SwapManager().PushNewStatus(s.OfferID(), status)
 }
 
 // ExpectedAmount returns the amount received, or expected to be received, at the end of the swap

--- a/protocol/xmrtaker/swap_state_ongoing_test.go
+++ b/protocol/xmrtaker/swap_state_ongoing_test.go
@@ -48,7 +48,7 @@ func setupSwapStateUntilETHLocked(t *testing.T) (*swapState, uint64) {
 	// shutdown swap state, re-create from ongoing
 	s.cancel()
 
-	rdb.EXPECT().GetCounterpartySwapKeys(s.info.OfferID).Return(
+	rdb.EXPECT().GetCounterpartySwapKeys(s.OfferID()).Return(
 		makerKeys.PublicKeyPair.SpendKey(),
 		makerKeys.PrivateKeyPair.ViewKey(),
 		nil,

--- a/protocol/xmrtaker/swap_state_test.go
+++ b/protocol/xmrtaker/swap_state_test.go
@@ -252,7 +252,7 @@ func TestSwapState_HandleProtocolMessage_SendKeysMessage_Refund(t *testing.T) {
 	require.Equal(t, xmrmakerKeysAndProof.PrivateKeyPair.ViewKey().String(), s.xmrmakerPrivateViewKey.String())
 
 	// ensure we refund before t1
-	for status := range s.info.StatusCh() {
+	for status := range s.SwapManager().GetStatusChan(s.OfferID()) {
 		if status == types.CompletedRefund {
 			// check this is before t1
 			// TODO: remove the 10-second buffer, this is needed for now
@@ -346,7 +346,7 @@ func TestSwapState_NotifyXMRLock_Refund(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, EventETHClaimedType, s.nextExpectedEvent)
 
-	for status := range s.info.StatusCh() {
+	for status := range s.SwapManager().GetStatusChan(s.OfferID()) {
 		if status == types.CompletedRefund {
 			// check this is after t2
 			require.Less(t, s.t2, time.Now())
@@ -368,7 +368,7 @@ func TestExit_afterSendKeysMessage(t *testing.T) {
 	s.nextExpectedEvent = EventKeysReceivedType
 	err := s.Exit()
 	require.NoError(t, err)
-	info, err := s.SwapManager().GetPastSwap(s.info.OfferID)
+	info, err := s.SwapManager().GetPastSwap(s.OfferID())
 	require.NoError(t, err)
 	require.Equal(t, types.CompletedAbort, info.Status)
 }
@@ -395,7 +395,7 @@ func TestExit_afterNotifyXMRLock(t *testing.T) {
 	err = s.Exit()
 	require.NoError(t, err)
 
-	info, err := s.SwapManager().GetPastSwap(s.info.OfferID)
+	info, err := s.SwapManager().GetPastSwap(s.OfferID())
 	require.NoError(t, err)
 	require.Equal(t, types.CompletedRefund, info.Status)
 }
@@ -422,7 +422,7 @@ func TestExit_afterNotifyClaimed(t *testing.T) {
 	err = s.Exit()
 	require.NoError(t, err)
 
-	info, err := s.SwapManager().GetPastSwap(s.info.OfferID)
+	info, err := s.SwapManager().GetPastSwap(s.OfferID())
 	require.NoError(t, err)
 	require.Equal(t, types.CompletedRefund, info.Status)
 }
@@ -450,7 +450,7 @@ func TestExit_invalidNextMessageType(t *testing.T) {
 	err = s.Exit()
 	require.True(t, errors.Is(err, errUnexpectedEventType))
 
-	info, err := s.SwapManager().GetPastSwap(s.info.OfferID)
+	info, err := s.SwapManager().GetPastSwap(s.OfferID())
 	require.NoError(t, err)
 	require.Equal(t, types.CompletedAbort, info.Status)
 }

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -81,16 +81,25 @@ func (*mockSwapManager) GetPastSwap(_ types.Hash) (*swap.Info, error) {
 	return &swap.Info{}, nil
 }
 
-func (*mockSwapManager) GetOngoingSwaps() ([]*swap.Info, error) {
+func (*mockSwapManager) GetOngoingSwap(_ types.Hash) (*swap.Info, error) {
+	return &swap.Info{}, nil
+}
+
+func (*mockSwapManager) GetOngoingSwapsSnapshot() ([]*swap.Info, error) {
 	return nil, nil
 }
 
-func (*mockSwapManager) GetOngoingSwap(id types.Hash) (swap.Info, error) {
-	statusCh := types.NewStatusChannel()
-	statusCh <- types.CompletedSuccess
+func (*mockSwapManager) GetOngoingSwapStatusCh(_ types.Hash) (chan types.Status, error) {
+	return nil, nil
+}
 
+func (*mockSwapManager) GetOngoingSwapOfferIDs() ([]*types.Hash, error) {
+	return nil, nil
+}
+
+func (*mockSwapManager) GetOngoingSwapSnapshot(id types.Hash) (*swap.Info, error) {
 	one := apd.New(1, 0)
-	return *swap.NewInfo(
+	return swap.NewInfo(
 		testPeerID,
 		id,
 		coins.ProvidesETH,
@@ -100,7 +109,6 @@ func (*mockSwapManager) GetOngoingSwap(id types.Hash) (swap.Info, error) {
 		types.EthAssetETH,
 		types.CompletedSuccess,
 		1,
-		statusCh,
 	), nil
 }
 
@@ -113,6 +121,18 @@ func (*mockSwapManager) CompleteOngoingSwap(_ *swap.Info) error {
 }
 
 func (*mockSwapManager) HasOngoingSwap(_ types.Hash) bool {
+	panic("not implemented")
+}
+
+func (*mockSwapManager) GetStatusChan(_ types.Hash) <-chan types.Status {
+	panic("not implemented")
+}
+
+func (*mockSwapManager) DeleteStatusChan(_ types.Hash) {
+	panic("not implemented")
+}
+
+func (*mockSwapManager) PushNewStatus(_ types.Hash, status types.Status) {
 	panic("not implemented")
 }
 
@@ -154,7 +174,6 @@ func (m *mockXMRMaker) GetOngoingSwapState(_ types.Hash) common.SwapState {
 
 func (*mockXMRMaker) MakeOffer(_ *types.Offer, _ bool) (*types.OfferExtra, error) {
 	offerExtra := types.NewOfferExtra(false)
-	offerExtra.StatusCh <- types.CompletedSuccess
 	return offerExtra, nil
 }
 

--- a/rpc/mocks_test.go
+++ b/rpc/mocks_test.go
@@ -86,7 +86,7 @@ func (*mockSwapManager) GetOngoingSwaps() ([]*swap.Info, error) {
 }
 
 func (*mockSwapManager) GetOngoingSwap(id types.Hash) (swap.Info, error) {
-	statusCh := make(chan types.Status, 1)
+	statusCh := types.NewStatusChannel()
 	statusCh <- types.CompletedSuccess
 
 	one := apd.New(1, 0)
@@ -153,9 +153,7 @@ func (m *mockXMRMaker) GetOngoingSwapState(_ types.Hash) common.SwapState {
 }
 
 func (*mockXMRMaker) MakeOffer(_ *types.Offer, _ bool) (*types.OfferExtra, error) {
-	offerExtra := &types.OfferExtra{
-		StatusCh: make(chan types.Status, 1),
-	}
+	offerExtra := types.NewOfferExtra(false)
 	offerExtra.StatusCh <- types.CompletedSuccess
 	return offerExtra, nil
 }

--- a/rpc/net_test.go
+++ b/rpc/net_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNet_Discover(t *testing.T) {
-	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, new(mockSwapManager), false)
+	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, mockSwapManager(t), false)
 
 	req := &rpctypes.DiscoverRequest{
 		Provides: "",
@@ -28,7 +28,7 @@ func TestNet_Discover(t *testing.T) {
 }
 
 func TestNet_Query(t *testing.T) {
-	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, new(mockSwapManager), false)
+	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, mockSwapManager(t), false)
 
 	req := &rpctypes.QueryPeerRequest{
 		PeerID: "12D3KooWDqCzbjexHEa8Rut7bzxHFpRMZyDRW1L6TGkL1KY24JH5",
@@ -42,7 +42,7 @@ func TestNet_Query(t *testing.T) {
 }
 
 func TestNet_TakeOffer(t *testing.T) {
-	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, new(mockSwapManager), false)
+	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, mockSwapManager(t), false)
 
 	req := &rpctypes.TakeOfferRequest{
 		PeerID:         "12D3KooWDqCzbjexHEa8Rut7bzxHFpRMZyDRW1L6TGkL1KY24JH5",
@@ -55,7 +55,7 @@ func TestNet_TakeOffer(t *testing.T) {
 }
 
 func TestNet_TakeOfferSync(t *testing.T) {
-	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, new(mockSwapManager), false)
+	ns := NewNetService(new(mockNet), new(mockXMRTaker), nil, mockSwapManager(t), false)
 
 	req := &rpctypes.TakeOfferRequest{
 		PeerID:         "12D3KooWDqCzbjexHEa8Rut7bzxHFpRMZyDRW1L6TGkL1KY24JH5",

--- a/rpc/prometheus.go
+++ b/rpc/prometheus.go
@@ -30,7 +30,7 @@ type Metrics struct {
 
 func pastSwapsMetric(
 	factory promauto.Factory,
-	swapManager SwapManager,
+	swapManager swap.Manager,
 	status swap.Status,
 	statusLabel string,
 ) prometheus.GaugeFunc {
@@ -108,7 +108,7 @@ func SetupMetrics(
 				Help:      "The number of ongoing swaps",
 			},
 			func() float64 {
-				swaps, err := swapManager.GetOngoingSwaps()
+				swaps, err := swapManager.GetOngoingSwapsSnapshot()
 				if err != nil {
 					return float64(-1)
 				}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -263,6 +263,3 @@ type XMRMaker interface {
 	ClearOffers([]types.Hash) error
 	GetMoneroBalance() (*mcrypto.Address, *wallet.GetBalanceResponse, error)
 }
-
-// SwapManager ...
-type SwapManager = swap.Manager

--- a/rpc/swap.go
+++ b/rpc/swap.go
@@ -24,7 +24,7 @@ import (
 // SwapService handles information about ongoing or past swaps.
 type SwapService struct {
 	ctx      context.Context
-	sm       SwapManager
+	sm       swap.Manager
 	xmrtaker XMRTaker
 	xmrmaker XMRMaker
 	net      Net
@@ -35,7 +35,7 @@ type SwapService struct {
 // NewSwapService ...
 func NewSwapService(
 	ctx context.Context,
-	sm SwapManager,
+	sm swap.Manager,
 	xmrtaker XMRTaker,
 	xmrmaker XMRMaker,
 	net Net,
@@ -165,17 +165,17 @@ func (s *SwapService) GetOngoing(_ *http.Request, req *GetOngoingRequest, resp *
 	)
 
 	if req.OfferID == nil {
-		swaps, err = s.sm.GetOngoingSwaps()
+		swaps, err = s.sm.GetOngoingSwapsSnapshot()
 		if err != nil {
 			return err
 		}
 	} else {
-		info, err := s.sm.GetOngoingSwap(*req.OfferID) //nolint:govet
+		info, err := s.sm.GetOngoingSwapSnapshot(*req.OfferID) //nolint:govet
 		if err != nil {
 			return err
 		}
 
-		swaps = []*swap.Info{&info}
+		swaps = []*swap.Info{info}
 	}
 
 	resp.Swaps = make([]*OngoingSwap, len(swaps))
@@ -221,7 +221,7 @@ type GetStatusResponse struct {
 
 // GetStatus returns the status of the ongoing swap, if there is one.
 func (s *SwapService) GetStatus(_ *http.Request, req *GetStatusRequest, resp *GetStatusResponse) error {
-	info, err := s.sm.GetOngoingSwap(req.ID)
+	info, err := s.sm.GetOngoingSwapSnapshot(req.ID)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ type CancelResponse struct {
 
 // Cancel attempts to cancel the currently ongoing swap, if there is one.
 func (s *SwapService) Cancel(_ *http.Request, req *CancelRequest, resp *CancelResponse) error {
-	info, err := s.sm.GetOngoingSwap(req.OfferID)
+	info, err := s.sm.GetOngoingSwapSnapshot(req.OfferID)
 	if err != nil {
 		return fmt.Errorf("failed to get ongoing swap: %w", err)
 	}

--- a/rpc/ws.go
+++ b/rpc/ws.go
@@ -266,8 +266,12 @@ func (s *wsServer) subscribeTakeOffer(ctx context.Context, conn *websocket.Conn,
 	}
 }
 
-func (s *wsServer) subscribeMakeOffer(ctx context.Context, conn *websocket.Conn,
-	offerID types.Hash, offerExtra *types.OfferExtra) error {
+func (s *wsServer) subscribeMakeOffer(
+	ctx context.Context,
+	conn *websocket.Conn,
+	offerID types.Hash,
+	offerExtra *types.OfferExtra,
+) error {
 	resp := &rpctypes.MakeOfferResponse{
 		PeerID:  s.ns.net.PeerID(),
 		OfferID: offerID,

--- a/rpc/ws.go
+++ b/rpc/ws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/athanorlabs/atomic-swap/common/types"
 	"github.com/athanorlabs/atomic-swap/common/vjson"
 	mcrypto "github.com/athanorlabs/atomic-swap/crypto/monero"
+	"github.com/athanorlabs/atomic-swap/protocol/swap"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/gorilla/websocket"
@@ -29,13 +30,13 @@ func checkOriginFunc(_ *http.Request) bool {
 
 type wsServer struct {
 	ctx     context.Context
-	sm      SwapManager
+	sm      swap.Manager
 	ns      *NetService
 	backend ProtocolBackend
 	taker   XMRTaker
 }
 
-func newWsServer(ctx context.Context, sm SwapManager, ns *NetService, backend ProtocolBackend,
+func newWsServer(ctx context.Context, sm swap.Manager, ns *NetService, backend ProtocolBackend,
 	taker XMRTaker) *wsServer {
 	s := &wsServer{
 		ctx:     ctx,
@@ -142,12 +143,12 @@ func (s *wsServer) handleRequest(conn *websocket.Conn, req *rpctypes.Request) er
 			return fmt.Errorf("failed to unmarshal parameters: %w", err)
 		}
 
-		ch, err := s.ns.takeOffer(params.PeerID, params.OfferID, params.ProvidesAmount)
+		err := s.ns.takeOffer(params.PeerID, params.OfferID, params.ProvidesAmount)
 		if err != nil {
 			return err
 		}
 
-		return s.subscribeTakeOffer(s.ctx, conn, ch)
+		return s.subscribeTakeOffer(s.ctx, conn, params.OfferID)
 	case rpctypes.SubscribeMakeOffer:
 		if s.ns == nil {
 			return errNamespaceNotEnabled
@@ -158,12 +159,12 @@ func (s *wsServer) handleRequest(conn *websocket.Conn, req *rpctypes.Request) er
 			return fmt.Errorf("failed to unmarshal parameters: %w", err)
 		}
 
-		offerResp, offerExtra, err := s.ns.makeOffer(params)
+		offerResp, err := s.ns.makeOffer(params)
 		if err != nil {
 			return err
 		}
 
-		return s.subscribeMakeOffer(s.ctx, conn, offerResp.OfferID, offerExtra)
+		return s.subscribeMakeOffer(s.ctx, conn, offerResp.OfferID)
 	default:
 		return errInvalidMethod
 	}
@@ -240,8 +241,14 @@ func (s *wsServer) handleSigner(
 	}
 }
 
-func (s *wsServer) subscribeTakeOffer(ctx context.Context, conn *websocket.Conn,
-	statusCh <-chan types.Status) error {
+func (s *wsServer) subscribeTakeOffer(
+	ctx context.Context,
+	conn *websocket.Conn,
+	offerID types.Hash,
+) error {
+
+	statusCh := s.sm.GetStatusChan(offerID)
+
 	for {
 		select {
 		case status, ok := <-statusCh:
@@ -270,7 +277,6 @@ func (s *wsServer) subscribeMakeOffer(
 	ctx context.Context,
 	conn *websocket.Conn,
 	offerID types.Hash,
-	offerExtra *types.OfferExtra,
 ) error {
 	resp := &rpctypes.MakeOfferResponse{
 		PeerID:  s.ns.net.PeerID(),
@@ -281,9 +287,11 @@ func (s *wsServer) subscribeMakeOffer(
 		return err
 	}
 
+	statusCh := s.backend.SwapManager().GetStatusChan(offerID)
+
 	for {
 		select {
-		case status, ok := <-offerExtra.StatusCh:
+		case status, ok := <-statusCh:
 			if !ok {
 				return nil
 			}
@@ -305,18 +313,19 @@ func (s *wsServer) subscribeMakeOffer(
 	}
 }
 
-// subscribeSwapStatus writes the swap's stage to the connection every time it updates.
-// when the swap completes, it writes the final status then closes the connection.
-// example: `{"jsonrpc":"2.0", "method":"swap_subscribeStatus", "params": {"id": 0}, "id": 0}`
-func (s *wsServer) subscribeSwapStatus(ctx context.Context, conn *websocket.Conn, id types.Hash) error {
-	// we can ignore the error here, since the error will only be if the swap cannot be found
-	// as ongoing, in which case `writeSwapExitStatus` will look for it in the past swaps.
-	info, err := s.sm.GetOngoingSwap(id)
-	if err != nil {
-		return s.writeSwapExitStatus(conn, id)
+// subscribeSwapStatus writes the swap's status transitions to the websockets
+// connection when the state changes. When the swap completes, it writes the
+// final status and then closes the connection. This method is not intended for
+// simultaneous requests on the same swap. If more than one request is made
+// (including calls to net_[make|take]OfferAndSubscribe), only one of the
+// websocket connections will see any individual state transition.
+func (s *wsServer) subscribeSwapStatus(ctx context.Context, conn *websocket.Conn, offerID types.Hash) error {
+	statusCh := s.backend.SwapManager().GetStatusChan(offerID)
+
+	if !s.sm.HasOngoingSwap(offerID) {
+		return s.writeSwapExitStatus(conn, offerID)
 	}
 
-	statusCh := info.StatusCh()
 	for {
 		select {
 		case status, ok := <-statusCh:

--- a/rpc/ws.go
+++ b/rpc/ws.go
@@ -148,7 +148,7 @@ func (s *wsServer) handleRequest(conn *websocket.Conn, req *rpctypes.Request) er
 			return err
 		}
 
-		return s.subscribeTakeOffer(s.ctx, conn, params.OfferID)
+		return s.subscribeSwapStatus(s.ctx, conn, params.OfferID)
 	case rpctypes.SubscribeMakeOffer:
 		if s.ns == nil {
 			return errNamespaceNotEnabled
@@ -237,38 +237,6 @@ func (s *wsServer) handleSigner(
 			}
 
 			txsInCh <- params.TxHash
-		}
-	}
-}
-
-func (s *wsServer) subscribeTakeOffer(
-	ctx context.Context,
-	conn *websocket.Conn,
-	offerID types.Hash,
-) error {
-
-	statusCh := s.sm.GetStatusChan(offerID)
-
-	for {
-		select {
-		case status, ok := <-statusCh:
-			if !ok {
-				return nil
-			}
-
-			resp := &rpctypes.SubscribeSwapStatusResponse{
-				Status: status,
-			}
-
-			if err := writeResponse(conn, resp); err != nil {
-				return err
-			}
-
-			if !status.IsOngoing() {
-				return nil
-			}
-		case <-ctx.Done():
-			return nil
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a new test case, `TestXMRNotLockedAndETHRefundedAfterAliceRestarts`, that was initially broken before the rest of the PR. The taker's status subscribe channel was not getting the refund status change after restart.

I decided to remove the status channel from both the `OfferExtra` and `swap.Info` struct types. Both of those types are designed for serialization (and deserialization on restart), but status channels are ephemeral to a single run of `swapd`. Instead of trying to keep the status channels synchronized across two different data structures, I made management of the channel part of `swap.Manager`.