### PR TITLE
query-all no longer reports peers with no current offers

### DIFF
--- a/rpc/net.go
+++ b/rpc/net.go
@@ -84,17 +84,19 @@ func (s *NetService) QueryAll(_ *http.Request, req *rpctypes.QueryAllRequest, re
 		return err
 	}
 
-	resp.PeersWithOffers = make([]*rpctypes.PeerWithOffers, len(peerIDs))
-	for i, p := range peerIDs {
-		resp.PeersWithOffers[i] = &rpctypes.PeerWithOffers{
-			PeerID: p,
-		}
+	resp.PeersWithOffers = make([]*rpctypes.PeerWithOffers, 0, len(peerIDs))
+	for _, p := range peerIDs {
 		msg, err := s.net.Query(p)
 		if err != nil {
 			log.Debugf("Failed to query peer ID %s", p)
 			continue
 		}
-		resp.PeersWithOffers[i].Offers = msg.Offers
+		if len(msg.Offers) > 0 {
+			resp.PeersWithOffers = append(resp.PeersWithOffers, &rpctypes.PeerWithOffers{
+				PeerID: p,
+				Offers: msg.Offers,
+			})
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The `query-all` command to `swapcli` was reporting nodes that had presumably offered XMR at some point, but didn't have any current offers. This PR just prunes nodes with no offers from the returned results.