### PR TITLE
renamed swap database directory

### DIFF
--- a/daemon/swap_daemon.go
+++ b/daemon/swap_daemon.go
@@ -29,6 +29,12 @@ import (
 	"github.com/athanorlabs/atomic-swap/rpc"
 )
 
+const (
+	// databaseDirName is the name of the folder, located in the swapd's
+	// data-dir, for the current and past swap information.
+	databaseDirName = "swap-db"
+)
+
 var log = logging.Logger("daemon")
 
 // SwapdConfig provides startup parameters for swapd.
@@ -63,7 +69,7 @@ func RunSwapDaemon(ctx context.Context, conf *SwapdConfig) (err error) {
 	// Initialize the database first, so the defer statement that closes it
 	// will get executed last.
 	sdb, err := db.NewDatabase(&chaindb.Config{
-		DataDir: path.Join(conf.EnvConf.DataDir, "db"),
+		DataDir: path.Join(conf.EnvConf.DataDir, databaseDirName),
 	})
 	if err != nil {
 		return err

--- a/docs/default-file-locations.md
+++ b/docs/default-file-locations.md
@@ -13,7 +13,7 @@ and `ENV` is the value from the `--env` flag (e.g. `stagenet`, `mainnet`).
 From here forward, we will use `{DATA_DIR}` to refer to this default value or the value
 passed with the `--data-dir` flag.
 
-### {DATA_DIR}/db
+### {DATA_DIR}/swap-db
 
 This is the location of swapd's (BadgerDB) database. Currently, it stores offers made so that 
 they can be reloaded on restart. The database can be safely deleted if you don't have any offers


### PR DESCRIPTION
In https://github.com/AthanorLabs/atomic-swap/pull/480, we upgraded `github.com/ChainSafe/chaindb` from the non-released commit hash `f900218c88f8` above release `v0.1.4` of  to a release that Chainsafe made 2 weeks ago tagged [v0.1.5](https://github.com/ChainSafe/chaindb/releases/tag/v0.1.5). The release tag is only changing the patch-level, so it should have been backwards compatible, but, sadly, it is not.

The `v0.1.5` chaindb release moves to [Badger v4.1.0](https://github.com/dgraph-io/badger/releases/tag/v4.1.0),  whose primary purpose is to fix 6 CVE's.

Attempting to run `swapd` with an existing database already in place gives this error:
```text
FATAL   cmd     swapd/main.go:228       manifest has unsupported version: 7 (we support 8).
Please see https://dgraph.io/docs/badger/faq/#i-see-manifest-has-unsupported-version-x-we-support-y-error on how to fix this.
```
This PR gives the database directory a new, more specific, name, to allow startup. That's probably good enough for most people, but we can give the link to that error message in the release notes for anyone that wants to salvage their swap history.

Feel free to suggest alternate ideas, this is just what I came up with.

