### PR TITLE
exchange rate labeling updates

### DIFF
--- a/cmd/swapcli/main.go
+++ b/cmd/swapcli/main.go
@@ -179,7 +179,7 @@ func cliApp() *cli.App {
 					},
 					&cli.StringFlag{
 						Name:     flagExchangeRate,
-						Usage:    "Desired exchange rate of XMR:ETH, eg. --exchange-rate=0.1 means 10XMR = 1ETH",
+						Usage:    "Desired exchange rate of XMR/ETH, eg. --exchange-rate=0.08 means 1 XMR = 0.08 ETH",
 						Required: true,
 					},
 					&cli.BoolFlag{
@@ -853,7 +853,7 @@ func runGetOngoingSwap(ctx *cli.Context) error {
 		fmt.Printf("Start time: %s\n", info.StartTime.Format(common.TimeFmtSecs))
 		fmt.Printf("Provided: %s %s\n", info.ProvidedAmount.Text('f'), providedCoin)
 		fmt.Printf("Receiving: %s %s\n", info.ExpectedAmount.Text('f'), receivedCoin)
-		fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
+		fmt.Printf("Exchange Rate: %s XMR/ETH\n", info.ExchangeRate)
 		fmt.Printf("Status: %s\n", info.Status)
 		fmt.Printf("Time status was last updated: %s\n", info.LastStatusUpdateTime.Format(common.TimeFmtSecs))
 		if info.Timeout1 != nil && info.Timeout2 != nil {
@@ -925,7 +925,7 @@ func runGetPastSwap(ctx *cli.Context) error {
 			)
 		}
 		fmt.Printf("\n")
-		fmt.Printf("Exchange Rate: %s ETH/XMR\n", info.ExchangeRate)
+		fmt.Printf("Exchange Rate: %s XMR/ETH\n", info.ExchangeRate)
 		fmt.Printf("Status: %s\n", info.Status)
 	}
 

--- a/pricefeed/pricefeed.go
+++ b/pricefeed/pricefeed.go
@@ -85,6 +85,12 @@ func GetXMRUSDPrice(ctx context.Context, ec *ethclient.Client) (*PriceFeed, erro
 		return nil, err
 	}
 
+	// Temporary hack to return a better error until the issue is resolved.
+	switch chainID.Uint64() {
+	case common.MainnetChainID, common.SepoliaChainID:
+		return nil, errors.New("https://github.com/AthanorLabs/atomic-swap/issues/492")
+	}
+
 	switch chainID.Uint64() {
 	case common.MainnetChainID:
 		// No extra work to do

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -38,6 +38,7 @@ func TestGetETHUSDPrice_dev(t *testing.T) {
 }
 
 func TestGetXMRUSDPrice_mainnet(t *testing.T) {
+	t.Skip("Chainlink XMR priceed is down: https://github.com/AthanorLabs/atomic-swap/issues/492")
 	ec := tests.NewEthMainnetClient(t)
 
 	feed, err := GetXMRUSDPrice(context.Background(), ec)

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -38,7 +38,7 @@ func TestGetETHUSDPrice_dev(t *testing.T) {
 }
 
 func TestGetXMRUSDPrice_mainnet(t *testing.T) {
-	t.Skip("Chainlink XMR priceed is down: https://github.com/AthanorLabs/atomic-swap/issues/492")
+	t.Skip("Chainlink XMR price feed is down: https://github.com/AthanorLabs/atomic-swap/issues/492")
 	ec := tests.NewEthMainnetClient(t)
 
 	feed, err := GetXMRUSDPrice(context.Background(), ec)


### PR DESCRIPTION
Someone put up a mainnet swap with an exchange rate of 0.1. I realized that our help could be clearer and while our code commentary in various places was correct on the numerator/denominator labeling, the swapcli output had it backwards.