### PR TITLE
Use prettier@2.8.8 instead of latest version for solidity formatting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install npm formatting/linting tools
-        run: npm install --global --save-dev prettier prettier-plugin-solidity solhint
+        run: npm install --global --save-dev prettier@2.8.8 prettier-plugin-solidity solhint
 
       # shellcheck should already be installed, but it doesn't hurt
       - name: Install apt formatting/linting tools

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -101,7 +101,7 @@ The solidity formatting uses an npm executable named `prettier` which, for solid
 needs a plugin called `prettier-plugin-solidity`. For solidity linting, we use the
 `solhint` program.
 ```
-npm install --global --save-dev prettier prettier-plugin-solidity
+npm install --global --save-dev prettier@2.8.8 prettier-plugin-solidity
 npm install --global --save-dev solhint
 ```
 


### PR DESCRIPTION
Some breaking change in prettier 3.0.0 (published to npm 3 days ago) made `make format` return errors:

```shell
[error] No parser could be inferred for file "atomic-swap/ethereum/block/testdata/UTContract.sol".
[error] No parser could be inferred for file "atomic-swap/ethereum/contracts/AggregatorV3Interface.sol".
[error] No parser could be inferred for file "atomic-swap/ethereum/contracts/TestERC20.sol".
[error] No parser could be inferred for file "atomic-swap/ethereum/contracts/Secp256k1.sol".
[error] No parser could be inferred for file "atomic-swap/ethereum/contracts/SwapCreator.sol".
```

This PR updates the **checks** github workflow (and the documentation) to use `prettier@2.8.8` instead of prettier's latest stable version.