### PR TITLE
made optimism endpoint configurable and changed default

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,10 +21,8 @@ jobs:
           go-version: '1.20.x'
       - uses: actions/checkout@v3
 
-      # Temporarily locking prettier at 2.8.8. See:
-      # https://github.com/AthanorLabs/atomic-swap/issues/501
       - name: Install npm formatting/linting tools
-        run: npm install --global --save-dev prettier@2.8.8 prettier-plugin-solidity solhint
+        run: npm install --global --save-dev prettier prettier-plugin-solidity solhint
 
       # shellcheck should already be installed, but it doesn't hurt
       - name: Install apt formatting/linting tools

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,8 +21,10 @@ jobs:
           go-version: '1.20.x'
       - uses: actions/checkout@v3
 
+      # Temporarily locking prettier at 2.8.8. See:
+      # https://github.com/AthanorLabs/atomic-swap/issues/501
       - name: Install npm formatting/linting tools
-        run: npm install --global --save-dev prettier prettier-plugin-solidity solhint
+        run: npm install --global --save-dev prettier@2.8.8 prettier-plugin-solidity solhint
 
       # shellcheck should already be installed, but it doesn't hurt
       - name: Install apt formatting/linting tools

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,6 +64,7 @@ jobs:
         env:
           ETH_MAINNET_ENDPOINT: ${{ secrets.ETH_MAINNET_ENDPOINT }}
           ETH_SEPOLIA_ENDPOINT: ${{ secrets.ETH_SEPOLIA_ENDPOINT }}
+          ETH_OPTIMISM_ENDPOINT: ${{ secrets.ETH_OPTIMISM_ENDPOINT }}
         run: ./scripts/run-unit-tests.sh
 
       - name: Upload code coverage

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOPATH ?= $(shell go env GOPATH)
+NPM_DIR = $(shell npm config get prefix)
 
 .PHONY: all
 all: install
@@ -14,7 +15,7 @@ lint-shell:
 
 .PHONY: lint-solidity
 lint-solidity: 
-	"$$(npm config get prefix)/bin/solhint" $$(find ethereum -name '*.sol' -not -path '**/@openzeppelin/**')
+	"$(NPM_DIR)/bin/solhint" $$(find ethereum -name '*.sol' -not -path '**/@openzeppelin/**')
 
 .PHONY: lint
 lint: lint-go lint-shell lint-solidity
@@ -30,7 +31,8 @@ format-shell:
 
 .PHONY: format-solidity
 format-solidity:
-	"$$(npm config get prefix)/bin/prettier" --print-width 100 --write \
+	"$(NPM_DIR)/bin/prettier" --print-width 100 --write \
+		--plugin="$(NPM_DIR)/lib/node_modules/prettier-plugin-solidity/src/index.js" \
 		$$(find ethereum -name '*.sol' -not -path '**/@openzeppelin/**')
 
 .PHONY: format

--- a/pricefeed/pricefeed_test.go
+++ b/pricefeed/pricefeed_test.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func newOptimismClient(t *testing.T) *ethclient.Client {
-	ec, err := ethclient.Dial(optimismEndpoint)
+	ec, err := ethclient.Dial(getOptimismEndpoint())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		ec.Close()


### PR DESCRIPTION
The initial Optimism endpoint that I picked, `https://1rpc.io/op`, has degraded. It now, on a semi-regular basis, just returns an EOF error. (Worse than other endpoints, that give a message about being over the rate limit or a connection-refused error.)

This PR picks a different endpoint, from `blockpi`, and also makes the optimism endpoint configurable via an `ETH_OPTIMISM_ENDPOINT` environment variable. The naming of the variable was picked to match the unit test variables for Sepolia and Mainnet, and this new variable can also be set in the github secrets for CI.

Note that this variable name does not match the CLI environment variables that can be used in place of a CLI flag. If we don't end up finding a reliable endpoint, we may want to add full CLI support for setting the endpoint and using a variable name like `SWAPD_OPTIMISM_ENDPOINT`.

This PR also adds a fix that is needed due to `prettier` changes in the new 3.0.0 release.